### PR TITLE
[PAS-982]:Add New Logic to redirect to GB-NI Allowances page from Residents page

### DIFF
--- a/app/controllers/UKResidentController.scala
+++ b/app/controllers/UKResidentController.scala
@@ -52,8 +52,12 @@ class UKResidentController @Inject()(
       },
       success = {
         isUKResident =>
-          travelDetailsService.storeUKResident(context.journeyData)(isUKResident).map(_ =>
-            Redirect(routes.TravelDetailsController.whereGoodsBought())
+          travelDetailsService.storeUKResident(context.journeyData)(isUKResident).map(f = _ =>
+            (context.getJourneyData.isUKVatPaid, context.getJourneyData.isUKExcisePaid, isUKResident) match {
+              case (Some(false), _, true) | (_, Some(false), true) => Redirect(routes.TravelDetailsController.goodsBoughtOutsideEu())
+              case _ => Redirect(routes.TravelDetailsController.whereGoodsBought())
+            }
+
           )
       })
   }

--- a/app/controllers/enforce/vatres/Steps.scala
+++ b/app/controllers/enforce/vatres/Steps.scala
@@ -9,26 +9,27 @@ import controllers.enforce.JourneyStep
 
 case object WhereGoodsBoughtStep extends JourneyStep(Nil, _ => _ => true)
 
-case object DidYouClaimTaxBackEuOnlyStep extends JourneyStep(preceeding = List(ArrivingNIStep), predicate = _ => x=> (x.flatMap(_.euCountryCheck) == Some("euOnly")) && x.flatMap(_.arrivingNICheck).isDefined)
+case object DidYouClaimTaxBackEuOnlyStep extends JourneyStep(preceeding = List(ArrivingNIStep), predicate = _ => x=> x.flatMap(_.euCountryCheck).contains("euOnly") && x.flatMap(_.arrivingNICheck).isDefined)
 
-case object GoodsBoughtOutsideEuStep extends JourneyStep(preceeding = List(ArrivingNIStep), predicate = _ => x=> (((x.flatMap(_.euCountryCheck) == Some("euOnly")) && x.flatMap(_.arrivingNICheck)== Some(false)))
-                                                                                                                  || ((x.flatMap(_.euCountryCheck)== Some("nonEuOnly")) && x.flatMap(_.arrivingNICheck).isDefined))
+case object GoodsBoughtOutsideEuStep extends JourneyStep(preceeding = List(ArrivingNIStep), predicate = _ => x=> (x.flatMap(_.euCountryCheck).contains("euOnly") && x.flatMap(_.arrivingNICheck).contains(false))
+                                                                                                                  || (x.flatMap(_.euCountryCheck).contains("nonEuOnly") && x.flatMap(_.arrivingNICheck).isDefined)
+                                                                                                                  || (x.flatMap(_.euCountryCheck).contains("greatBritain") && x.flatMap(_.arrivingNICheck).contains(true)))
 
-case object DidYouClaimTaxBackBothStep extends JourneyStep(preceeding = List(ArrivingNIStep), predicate = _ => x=> (x.flatMap(_.euCountryCheck) == Some("both")) && x.flatMap(_.arrivingNICheck).isDefined)
+case object DidYouClaimTaxBackBothStep extends JourneyStep(preceeding = List(ArrivingNIStep), predicate = _ => x=> x.flatMap(_.euCountryCheck).contains("both") && x.flatMap(_.arrivingNICheck).isDefined)
 
-case object BringingDutyFreeEuStep extends JourneyStep(preceeding = List(DidYouClaimTaxBackEuOnlyStep), predicate = _ => _.flatMap(_.isVatResClaimed) == Some(false))
+case object BringingDutyFreeEuStep extends JourneyStep(preceeding = List(DidYouClaimTaxBackEuOnlyStep), predicate = _ => _.flatMap(_.isVatResClaimed).contains(false))
 
-case object GoodsBoughtInsideEuStep extends JourneyStep(preceeding = List(ArrivingNIStep), predicate = _ => x=> (x.flatMap(_.euCountryCheck) == Some("euOnly")) && x.flatMap(_.arrivingNICheck) == Some(true))
+case object GoodsBoughtInsideEuStep extends JourneyStep(preceeding = List(ArrivingNIStep), predicate = _ => x=> x.flatMap(_.euCountryCheck).contains("euOnly") && x.flatMap(_.arrivingNICheck).contains(true))
 
-case object DeclareDutyFreeEuStep extends JourneyStep(preceeding = List(BringingDutyFreeEuStep), predicate = _ => _.flatMap(_.isBringingDutyFree) == Some(true))
+case object DeclareDutyFreeEuStep extends JourneyStep(preceeding = List(BringingDutyFreeEuStep), predicate = _ => _.flatMap(_.isBringingDutyFree).contains(true))
 
-case object BringingDutyFreeBothStep extends JourneyStep(preceeding = List(DidYouClaimTaxBackBothStep), predicate = _ => _.flatMap(_.isVatResClaimed) == Some(false))
+case object BringingDutyFreeBothStep extends JourneyStep(preceeding = List(DidYouClaimTaxBackBothStep), predicate = _ => _.flatMap(_.isVatResClaimed).contains(false))
 
-case object GoodsBoughtInAndOutEuStep extends JourneyStep(preceeding = List(BringingDutyFreeBothStep), predicate = _ => _.flatMap(_.isBringingDutyFree) == Some(false))
+case object GoodsBoughtInAndOutEuStep extends JourneyStep(preceeding = List(BringingDutyFreeBothStep), predicate = _ => _.flatMap(_.isBringingDutyFree).contains(false))
 
-case object DeclareDutyFreeMixStep extends JourneyStep(preceeding = List(BringingDutyFreeBothStep), predicate = _ => _.flatMap(_.isBringingDutyFree) == Some(true))
+case object DeclareDutyFreeMixStep extends JourneyStep(preceeding = List(BringingDutyFreeBothStep), predicate = _ => _.flatMap(_.isBringingDutyFree).contains(true))
 
-case object NoNeedToUseStep extends JourneyStep(preceeding = List(GoodsBoughtInAndOutEuStep, GoodsBoughtOutsideEuStep, DeclareDutyFreeMixStep, DeclareDutyFreeEuStep), predicate = _ => _.flatMap(_.bringingOverAllowance) == Some(false))
+case object NoNeedToUseStep extends JourneyStep(preceeding = List(GoodsBoughtInAndOutEuStep, GoodsBoughtOutsideEuStep, DeclareDutyFreeMixStep, DeclareDutyFreeEuStep), predicate = _ => _.flatMap(_.bringingOverAllowance).contains(false))
 
 case object Is17OrOverStep extends JourneyStep(preceeding = List(PrivateCraftStep), predicate = _ => _.flatMap(_.privateCraft).isDefined)
 
@@ -36,7 +37,7 @@ case object DashboardStep extends JourneyStep(preceeding = List(Is17OrOverStep),
 
 case object ArrivingNIStep extends JourneyStep(preceeding = List(WhereGoodsBoughtStep), predicate = _ => _.flatMap(_.euCountryCheck).isDefined)
 
-case object UKVatPaidStep extends JourneyStep(preceeding = List(ArrivingNIStep), predicate = _ => x=> (x.flatMap(_.euCountryCheck) == Some("greatBritain")) && x.flatMap(_.arrivingNICheck) == Some(true))
+case object UKVatPaidStep extends JourneyStep(preceeding = List(ArrivingNIStep), predicate = _ => x=> x.flatMap(_.euCountryCheck).contains("greatBritain") && x.flatMap(_.arrivingNICheck).contains(true))
 
 case object UKExcisePaidStep extends JourneyStep(preceeding = List(UKVatPaidStep), predicate = _ => _.flatMap(_.isUKVatPaid).isDefined)
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 import TestPhases.oneForkedJvmPerTest
 import uk.gov.hmrc.DefaultBuildSettings.{addTestReportOption, defaultSettings, scalaSettings, targetJvm}
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin.publishingSettings
-
 import sbt.Keys._
 import sbt._
+import scoverage.ScoverageKeys
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin
 import uk.gov.hmrc.versioning.SbtGitVersioning
 
@@ -30,7 +30,12 @@ lazy val microservice = Project(appName, file("."))
     parallelExecution in Test := false,
     fork in Test := false
   )
-  //.settings(SbtBuildInfo(): _*)
+  .settings(
+    ScoverageKeys.coverageExcludedFiles := "<empty>;Reverse.*;.*filters.*;.*handlers.*;.*components.*;.*repositories.*;" +
+      ".*BuildInfo.*;.*javascript.*;.*FrontendAuditConnector.*;.*Routes.*;.*GuiceInjector;" +
+      ".*ControllerConfiguration;.*LocalLanguageController;.*testonly.*;",
+    ScoverageKeys.coverageMinimum := 80
+  )
   .configs(IntegrationTest)
   .settings(
     inConfig(IntegrationTest)(Defaults.itSettings),

--- a/test/controllers/UKExcisePaidControllerSpec.scala
+++ b/test/controllers/UKExcisePaidControllerSpec.scala
@@ -44,7 +44,7 @@ class UKExcisePaidControllerSpec extends BaseSpec {
   }
   "loadUKExcisePaidPage" should {
     "load the page" in {
-      when(mockCache.fetch(any())).thenReturn(Future.successful(Some(JourneyData(Some("greatBritain"), Some(true), Some(true), Some(true)))))
+      when(mockCache.fetch(any())).thenReturn(Future.successful(Some(JourneyData(Some("greatBritain"), Some(true), Some(true)))))
       val result: Future[Result] = route(app, EnhancedFakeRequest("GET", "/check-tax-on-goods-you-bring-into-the-uk/gb-ni-excise-check")).get
       status(result) shouldBe OK
 

--- a/test/controllers/UKResidentControllerSpec.scala
+++ b/test/controllers/UKResidentControllerSpec.scala
@@ -9,7 +9,7 @@ import config.AppConfig
 import connectors.Cache
 import models.JourneyData
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.Matchers.{eq => meq, _}
 import org.mockito.Mockito.{reset, times, verify, when}
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.Application
@@ -75,6 +75,54 @@ class UKResidentControllerSpec extends BaseSpec {
   }
 
   "postUKResidentPage" should {
+
+    "redirect to .../goods-bought-outside-eu when user travels from GB to NI and answered NO for UK VAT paid and YES for Excise paid and UK resident" in  {
+
+      val cachedJourneyData = Future.successful(Some(JourneyData(euCountryCheck = Some("greatBritain"),Some(true),Some(false),Some(true),Some(true))))
+
+      when(mockCache.fetch(any())) thenReturn cachedJourneyData
+      when(mockTravelDetailService.storeUKResident(any())(any())(any())) thenReturn cachedJourneyData
+
+      val response = route(app, EnhancedFakeRequest("POST", "/check-tax-on-goods-you-bring-into-the-uk/gb-ni-uk-resident-check")
+        .withFormUrlEncodedBody("isUKResident" -> "true")).get
+
+      status(response) shouldBe SEE_OTHER
+      redirectLocation(response) shouldBe Some("/check-tax-on-goods-you-bring-into-the-uk/goods-bought-outside-eu")
+
+      verify(mockTravelDetailService, times(1)).storeUKResident(any())(meq(true))(any())
+    }
+
+    "redirect to .../goods-bought-outside-eu when user travels from GB to NI and answered NO for Excise paid and YES for UK VAT paid and UK resident" in  {
+
+      val cachedJourneyData = Future.successful(Some(JourneyData(euCountryCheck = Some("greatBritain"),Some(true),Some(true),Some(false),Some(true))))
+
+      when(mockCache.fetch(any())) thenReturn cachedJourneyData
+      when(mockTravelDetailService.storeUKResident(any())(any())(any())) thenReturn cachedJourneyData
+
+      val response = route(app, EnhancedFakeRequest("POST", "/check-tax-on-goods-you-bring-into-the-uk/gb-ni-uk-resident-check")
+        .withFormUrlEncodedBody("isUKResident" -> "true")).get
+
+      status(response) shouldBe SEE_OTHER
+      redirectLocation(response) shouldBe Some("/check-tax-on-goods-you-bring-into-the-uk/goods-bought-outside-eu")
+
+      verify(mockTravelDetailService, times(1)).storeUKResident(any())(meq(true))(any())
+    }
+
+    "redirect to .../uk-resident-no-need-to-use-service when user travels from GB to NI and has answered YES for UK VAT, Excise paid and UK resident" in  {
+
+      val cachedJourneyData = Future.successful(Some(JourneyData(euCountryCheck = Some("greatBritain"),Some(true),Some(true),Some(true),Some(true))))
+
+      when(mockCache.fetch(any())) thenReturn cachedJourneyData
+      when(mockTravelDetailService.storeUKResident(any())(any())(any())) thenReturn cachedJourneyData
+
+      val response = route(app, EnhancedFakeRequest("POST", "/check-tax-on-goods-you-bring-into-the-uk/gb-ni-uk-resident-check")
+        .withFormUrlEncodedBody("isUKResident" -> "true")).get
+
+      status(response) shouldBe SEE_OTHER
+      redirectLocation(response) shouldBe Some("/check-tax-on-goods-you-bring-into-the-uk/where-goods-bought") // TODO add kick out url once the page implemented
+
+      verify(mockTravelDetailService, times(1)).storeUKResident(any())(meq(true))(any())
+    }
 
     "return a bad request when user selects an invalid value" in  {
 


### PR DESCRIPTION
# PAS-982
# New feature
1. Summary: Add New Logic to redirect to GB-NI Allowances page from Residents page
2. Link to AT PR: https://github.com/hmrc/bc-passengers-acceptance-tests/pull/126 
# PR Suggestions
- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
- Have you done a visual check of the changes?
- Is there any still commented or unused code? Lingering printlns?
- Have things been implemented in a complicated way?
- Are the test still over the coverage threshold?
- Does the compiler throw a lot of warnings? 
- Have methods and tests been named clearly?
- Were there any changes in the config? Do changes need to be made in app-config-???

# Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

# Checklist PR Reviewer
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date