### PR TITLE
[PAS-1105]:Put Actual Values For Currency, Country, Port of Entry in Declaration DB

### DIFF
--- a/app/services/DeclarationService.scala
+++ b/app/services/DeclarationService.scala
@@ -31,6 +31,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class DeclarationService @Inject()(
   val cache: Cache,
   val wsAllMethods: WsAllMethods,
+  val portsOfArrivalService: PortsOfArrivalService,
   servicesConfig: ServicesConfig,
   auditConnector: AuditConnector,
   auditingTools: AuditingTools,
@@ -119,8 +120,12 @@ class DeclarationService @Inject()(
         }
       }
 
-      def getPlaceOfArrival: String = {
+      def getPlaceOfArrivalCode: String = {
         if (o.selectPlaceOfArrival.isEmpty) o.enterPlaceOfArrival else o.selectPlaceOfArrival
+      }
+
+      def getPlaceOfArrival: String = {
+        if (o.selectPlaceOfArrival.isEmpty) o.enterPlaceOfArrival else messages(portsOfArrivalService.getDisplayNameByCode(o.selectPlaceOfArrival).getOrElse(""))
       }
 
       def getTravellingFrom: String = {
@@ -138,7 +143,8 @@ class DeclarationService @Inject()(
         }
       }
 
-      Json.obj("portOfEntry" -> getPlaceOfArrival,
+      Json.obj("portOfEntry" -> getPlaceOfArrivalCode,
+                      "portOfEntryName" -> getPlaceOfArrival,
                       "expectedDateOfArrival" -> o.dateOfArrival,
                       "timeOfEntry" -> s"${formattedTwoDecimals(o.timeOfArrival.getHourOfDay)}:${formattedTwoDecimals(o.timeOfArrival.getMinuteOfHour)}",
                       "messageTypes" -> Json.obj("messageType" -> servicesConfig.getString("declarations.create")),
@@ -172,7 +178,9 @@ class DeclarationService @Inject()(
                 "weight" -> item.weightOrVolume.fold[JsValue](JsNull)(x => JsString((x * 1000).toString())),
                 "goodsValue" -> item.metadata.cost,
                 "valueCurrency" -> item.metadata.currency.code,
+                "valueCurrencyName" -> messages(item.metadata.currency.displayName),
                 "originCountry" -> item.metadata.country.alphaTwoCode,
+                "originCountryName" -> messages(item.metadata.country.countryName),
                 "exchangeRate" -> {
                   val exchangeRate = BigDecimal(item.metadata.exchangeRate.rate)
                   if (exchangeRate.scale < 2) exchangeRate.setScale(2).toString() else exchangeRate.toString()
@@ -205,7 +213,9 @@ class DeclarationService @Inject()(
                 "volume" -> item.weightOrVolume.fold[JsValue](JsNull)(x => JsString(x.toString())),
                 "goodsValue" -> item.metadata.cost,
                 "valueCurrency" -> item.metadata.currency.code,
+                "valueCurrencyName" -> messages(item.metadata.currency.displayName),
                 "originCountry" -> item.metadata.country.alphaTwoCode,
+                "originCountryName" -> messages(item.metadata.country.countryName),
                 "exchangeRate" -> {
                   val exchangeRate = BigDecimal(item.metadata.exchangeRate.rate)
                   if (exchangeRate.scale < 2) exchangeRate.setScale(2).toString() else exchangeRate.toString()
@@ -238,7 +248,9 @@ class DeclarationService @Inject()(
                 "quantity" -> "1",
                 "goodsValue" -> item.metadata.cost,
                 "valueCurrency" -> item.metadata.currency.code,
+                "valueCurrencyName" -> messages(item.metadata.currency.displayName),
                 "originCountry" -> item.metadata.country.alphaTwoCode,
+                "originCountryName" -> messages(item.metadata.country.countryName),
                 "exchangeRate" -> {
                   val exchangeRate = BigDecimal(item.metadata.exchangeRate.rate)
                   if (exchangeRate.scale < 2) exchangeRate.setScale(2).toString() else exchangeRate.toString()

--- a/test/services/DeclarationServiceSpec.scala
+++ b/test/services/DeclarationServiceSpec.scala
@@ -67,7 +67,7 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
     Some(Alcohol(
       List(
         Band("B", List(
-          Item("ALC/A1/CIDER", "91.23", None, Some(5), Calculation("2.00", "0.30", "18.70", "21.00"), Metadata("5 litres cider", "label.alcohol.cider", "120.00", Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
+          Item("ALC/A1/CIDER", "91.23", None, Some(5), Calculation("2.00", "0.30", "18.70", "21.00"), Metadata("5 litres cider", "label.alcohol.cider", "120.00", Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
         ),
         Calculation("2.00", "0.30", "18.70", "21.00"))
       ),
@@ -76,8 +76,8 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
     Some(Tobacco(
       List(
         Band("B", List(
-          Item("TOB/A1/CIGRT", "304.11", Some(250), None, Calculation("74.00", "79.06", "91.43", "244.49"), Metadata("250 cigarettes", "label.tobacco.cigarettes", "400.00", Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29"))),
-          Item("TOB/A1/HAND", "152.05", Some(0), Some(0.12), Calculation("26.54", "113.88", "58.49", "198.91"), Metadata("120g rolling tobacco", "label.tobacco.rolling-tobacco", "200.00", Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
+          Item("TOB/A1/CIGRT", "304.11", Some(250), None, Calculation("74.00", "79.06", "91.43", "244.49"), Metadata("250 cigarettes", "label.tobacco.cigarettes", "400.00", Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29"))),
+          Item("TOB/A1/HAND", "152.05", Some(0), Some(0.12), Calculation("26.54", "113.88", "58.49", "198.91"), Metadata("120g rolling tobacco", "label.tobacco.rolling-tobacco", "200.00", Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
         ),
         Calculation("100.54", "192.94", "149.92", "443.40"))
       ),
@@ -86,8 +86,8 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
     Some(OtherGoods(
       List(
         Band("C",List(
-          Item("OGD/DIGI/TV", "1140.42", None, None, Calculation("0.00", "159.65", "260.01", "419.66"), Metadata("Televisions", "label.other-goods.electronic-devices.televisions", "1500.00", Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29"))),
-          Item("OGD/DIGI/TV", "1300.00", None, None, Calculation("0.00", "182.00", "296.40", "478.40"), Metadata("Televisions", "label.other-goods.electronic-devices.televisions", "1300.00", Currency("GBP", "British Pound (GBP)", None, Nil), Country("GB", "United Kingdom of Great Britain and Northern Ireland (the)", "GB", isEu = true, Nil), ExchangeRate("1.2", "2018-10-29")))
+          Item("OGD/DIGI/TV", "1140.42", None, None, Calculation("0.00", "159.65", "260.01", "419.66"), Metadata("Televisions", "label.other-goods.electronic-devices.televisions", "1500.00", Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29"))),
+          Item("OGD/DIGI/TV", "1300.00", None, None, Calculation("0.00", "182.00", "296.40", "478.40"), Metadata("Televisions", "label.other-goods.electronic-devices.televisions", "1300.00", Currency("GBP", "British pounds (GBP)", None, Nil), Country("GB", "United Kingdom", "GB", isEu = true, Nil), ExchangeRate("1.2", "2018-10-29")))
         ),
         Calculation("0.00", "341.65", "556.41", "898.06"))
       ),
@@ -115,7 +115,7 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
         "customerReference" -> Json.obj("idType" -> "passport", "idValue" -> "SX12345", "ukResident" -> false),
         "personalDetails" -> Json.obj("firstName" -> "Harry", "lastName" -> "Potter"),
         "contactDetails" -> Json.obj("emailAddress" -> "abc@gmail.com"),
-        "declarationHeader" -> Json.obj("chargeReference" -> "XJPR5768524625", "portOfEntry" -> "LHR", "expectedDateOfArrival" -> "2018-05-31", "timeOfEntry" -> "13:20", "messageTypes" -> Json.obj("messageType" -> "DeclarationCreate"), "travellingFrom" -> "NON_EU Only", "onwardTravelGBNI" -> "GB", "uccRelief" -> false, "ukVATPaid" -> false, "ukExcisePaid" -> false),
+        "declarationHeader" -> Json.obj("chargeReference" -> "XJPR5768524625", "portOfEntry" -> "LHR", "portOfEntryName" -> "Heathrow Airport", "expectedDateOfArrival" -> "2018-05-31", "timeOfEntry" -> "13:20", "messageTypes" -> Json.obj("messageType" -> "DeclarationCreate"), "travellingFrom" -> "NON_EU Only", "onwardTravelGBNI" -> "GB", "uccRelief" -> false, "ukVATPaid" -> false, "ukExcisePaid" -> false),
         "declarationTobacco" -> Json.obj(
           "totalExciseTobacco" -> "100.54",
           "totalCustomsTobacco" -> "192.94",
@@ -126,7 +126,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
               "quantity" -> "250",
               "goodsValue" -> "400.00",
               "valueCurrency" -> "USD",
+              "valueCurrencyName" -> "USA dollars (USD)",
               "originCountry" -> "US",
+              "originCountryName" -> "United States of America",
               "exchangeRate" -> "1.20",
               "exchangeRateDate" -> "2018-10-29",
               "goodsValueGBP" -> "304.11",
@@ -140,7 +142,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
               "weight" -> "120.00",
               "goodsValue" -> "200.00",
               "valueCurrency" -> "USD",
+              "valueCurrencyName" -> "USA dollars (USD)",
               "originCountry" -> "US",
+              "originCountryName" -> "United States of America",
               "exchangeRate" -> "1.20",
               "exchangeRateDate" -> "2018-10-29",
               "goodsValueGBP" -> "152.05",
@@ -161,7 +165,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
               "volume" -> "5",
               "goodsValue" -> "120.00",
               "valueCurrency" -> "USD",
+              "valueCurrencyName" -> "USA dollars (USD)",
               "originCountry" -> "US",
+              "originCountryName" -> "United States of America",
               "exchangeRate" -> "1.20",
               "exchangeRateDate" -> "2018-10-29",
               "goodsValueGBP" -> "91.23",
@@ -182,7 +188,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
               "quantity" -> "1",
               "goodsValue" -> "1500.00",
               "valueCurrency" -> "USD",
+              "valueCurrencyName" -> "USA dollars (USD)",
               "originCountry" -> "US",
+              "originCountryName" -> "United States of America",
               "exchangeRate" -> "1.20",
               "exchangeRateDate" -> "2018-10-29",
               "goodsValueGBP" -> "1140.42",
@@ -196,7 +204,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
               "quantity" -> "1",
               "goodsValue" -> "1300.00",
               "valueCurrency" -> "GBP",
+              "valueCurrencyName" -> "British pounds (GBP)",
               "originCountry" -> "GB",
+              "originCountryName" -> "United Kingdom",
               "exchangeRate" -> "1.20",
               "exchangeRateDate" -> "2018-10-29",
               "goodsValueGBP" -> "1300.00",
@@ -319,7 +329,7 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
           List(
             Band("A",
               List(
-                Item("ALC/A1/CIDER", "250.10", None, Some(BigDecimal("2.00")), Calculation("0.00", "0.00", "0.00", "0.00"), Metadata("2 litres cider", "Cider but for some reason has a really long product description", "300.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
+                Item("ALC/A1/CIDER", "250.10", None, Some(BigDecimal("2.00")), Calculation("0.00", "0.00", "0.00", "0.00"), Metadata("2 litres cider", "Cider but for some reason has a really long product description", "300.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
               ),
               Calculation("0.00", "0.00", "0.00", "0.00")
             )
@@ -352,7 +362,7 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
             "customerReference" -> Json.obj("idType" -> "passport", "idValue" -> "SX12345", "ukResident" -> false),
             "personalDetails" -> Json.obj("firstName" -> "Harry", "lastName" -> "Potter"),
             "contactDetails" -> Json.obj("emailAddress" -> "abc@gmail.com"),
-            "declarationHeader" -> Json.obj("portOfEntry" -> "LHR", "expectedDateOfArrival" -> "2018-05-31", "timeOfEntry" -> "08:02", "messageTypes" -> Json.obj("messageType" -> "DeclarationCreate"), "travellingFrom" -> "EU Only", "onwardTravelGBNI" -> "GB", "uccRelief" -> false, "ukVATPaid" -> false, "ukExcisePaid" -> false),
+            "declarationHeader" -> Json.obj("portOfEntry" -> "LHR", "portOfEntryName" -> "Heathrow Airport", "expectedDateOfArrival" -> "2018-05-31", "timeOfEntry" -> "08:02", "messageTypes" -> Json.obj("messageType" -> "DeclarationCreate"), "travellingFrom" -> "EU Only", "onwardTravelGBNI" -> "GB", "uccRelief" -> false, "ukVATPaid" -> false, "ukExcisePaid" -> false),
             "declarationAlcohol" -> Json.obj(
               "totalExciseAlcohol" -> "100.54",
               "totalCustomsAlcohol" -> "192.94",
@@ -363,7 +373,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "volume" -> "2.00",
                   "goodsValue" -> "300.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "250.10",
@@ -400,14 +412,14 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
           List(
             Band("A",
               List(
-                Item("ALC/A1/CIDER", "250.10", None, Some(BigDecimal("2.00")), Calculation("0.00", "0.00", "0.00", "0.00"), Metadata("2 litres cider", "Cider", "300.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
+                Item("ALC/A1/CIDER", "250.10", None, Some(BigDecimal("2.00")), Calculation("0.00", "0.00", "0.00", "0.00"), Metadata("2 litres cider", "Cider", "300.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
               ),
               Calculation("0.00", "0.00", "0.00", "0.00")
             ),
             Band("B",
               List(
-                Item("ALC/A2/BEER", "304.11", None, Some(BigDecimal("3.00")), Calculation("74.00", "79.06", "91.43", "244.49"),Metadata("3 litres beer", "Beer", "400.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29"))),
-                Item("ALC/A3/WINE", "152.05", None, Some(BigDecimal("4.00")), Calculation("26.54", "113.88", "58.49", "198.91"), Metadata("4 litres wine", "Wine", "200.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
+                Item("ALC/A2/BEER", "304.11", None, Some(BigDecimal("3.00")), Calculation("74.00", "79.06", "91.43", "244.49"),Metadata("3 litres beer", "Beer", "400.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29"))),
+                Item("ALC/A3/WINE", "152.05", None, Some(BigDecimal("4.00")), Calculation("26.54", "113.88", "58.49", "198.91"), Metadata("4 litres wine", "Wine", "200.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
               ),
               Calculation("100.54", "192.94", "149.92", "443.40")
             )
@@ -418,14 +430,14 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
           List(
             Band("A",
               List(
-                Item("OGD/CLTHS/CHILD", "250.10", None, None, Calculation("0.00", "0.00", "0.00", "0.00"), Metadata("children's clothes", "Children's Clothes", "300.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
+                Item("OGD/CLTHS/CHILD", "250.10", None, None, Calculation("0.00", "0.00", "0.00", "0.00"), Metadata("children's clothes", "Children's Clothes", "300.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
               ),
               Calculation("0.00", "0.00", "0.00", "0.00")
             ),
             Band("B",
               List(
-                Item("OGD/BKS/MISC", "304.11", None, None, Calculation("74.00", "79.06", "91.43", "244.49"),Metadata("books or publications", "Books or Publications", "400.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29"))),
-                Item("OGD/BKS/MISC", "152.05", None, None, Calculation("26.54", "113.88", "58.49", "198.91"), Metadata("books or publications", "Books or Publications", "200.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
+                Item("OGD/BKS/MISC", "304.11", None, None, Calculation("74.00", "79.06", "91.43", "244.49"),Metadata("books or publications", "Books or Publications", "400.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29"))),
+                Item("OGD/BKS/MISC", "152.05", None, None, Calculation("26.54", "113.88", "58.49", "198.91"), Metadata("books or publications", "Books or Publications", "200.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
               ),
               Calculation("100.54", "192.94", "149.92", "443.40")
             )
@@ -436,14 +448,14 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
           List(
             Band("A",
               List(
-                Item("TOB/A1/CIGRT", "250.10", Some(200), None, Calculation("0.00", "0.00", "0.00", "0.00"), Metadata("200 cigarettes", "Cigarettes", "300.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
+                Item("TOB/A1/CIGRT", "250.10", Some(200), None, Calculation("0.00", "0.00", "0.00", "0.00"), Metadata("200 cigarettes", "Cigarettes", "300.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
               ),
               Calculation("0.00", "0.00", "0.00", "0.00")
             ),
             Band("B",
               List(
-                Item("TOB/A1/CIGRT", "304.11",Some(250),None, Calculation("74.00", "79.06", "91.43", "244.49"),Metadata("250 cigarettes", "Cigarettes", "400.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29"))),
-                Item("TOB/A1/HAND", "152.05",Some(0),Some(BigDecimal("0.12")), Calculation("26.54", "113.88", "58.49", "198.91"), Metadata("120g rolling tobacco", "Rolling Tobacco", "200.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
+                Item("TOB/A1/CIGRT", "304.11",Some(250),None, Calculation("74.00", "79.06", "91.43", "244.49"),Metadata("250 cigarettes", "Cigarettes", "400.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29"))),
+                Item("TOB/A1/HAND", "152.05",Some(0),Some(BigDecimal("0.12")), Calculation("26.54", "113.88", "58.49", "198.91"), Metadata("120g rolling tobacco", "Rolling Tobacco", "200.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
               ),
               Calculation("100.54", "192.94", "149.92", "443.40")
             )
@@ -475,7 +487,7 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
             "customerReference" -> Json.obj("idType" -> "passport", "idValue" -> "SX12345", "ukResident" -> false),
             "personalDetails" -> Json.obj("firstName" -> "Harry", "lastName" -> "Potter"),
             "contactDetails" -> Json.obj("emailAddress" -> "abc@gmail.com"),
-            "declarationHeader" -> Json.obj("portOfEntry" -> "LHR", "expectedDateOfArrival" -> "2018-05-31", "timeOfEntry" -> "13:20", "messageTypes" -> Json.obj("messageType" -> "DeclarationCreate"), "travellingFrom" -> "NON_EU Only", "onwardTravelGBNI" -> "NI", "uccRelief" -> false, "ukVATPaid" -> false, "ukExcisePaid" -> false),
+            "declarationHeader" -> Json.obj("portOfEntry" -> "LHR", "portOfEntryName" -> "Heathrow Airport", "expectedDateOfArrival" -> "2018-05-31", "timeOfEntry" -> "13:20", "messageTypes" -> Json.obj("messageType" -> "DeclarationCreate"), "travellingFrom" -> "NON_EU Only", "onwardTravelGBNI" -> "NI", "uccRelief" -> false, "ukVATPaid" -> false, "ukExcisePaid" -> false),
             "declarationTobacco" -> Json.obj(
               "totalExciseTobacco" -> "100.54",
               "totalCustomsTobacco" -> "192.94",
@@ -486,7 +498,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "quantity" -> "200",
                   "goodsValue" -> "300.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "250.10",
@@ -500,7 +514,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "quantity" -> "250",
                   "goodsValue" -> "400.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "304.11",
@@ -514,7 +530,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "weight" -> "120.00",
                   "goodsValue" -> "200.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "152.05",
@@ -535,7 +553,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "volume" -> "2.00",
                   "goodsValue" -> "300.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "250.10",
@@ -549,7 +569,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "volume" -> "3.00",
                   "goodsValue" -> "400.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "304.11",
@@ -563,7 +585,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "volume" -> "4.00",
                   "goodsValue" -> "200.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "152.05",
@@ -584,7 +608,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "quantity" -> "1",
                   "goodsValue" -> "300.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "250.10",
@@ -598,7 +624,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "quantity" -> "1",
                   "goodsValue" -> "400.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "304.11",
@@ -612,7 +640,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "quantity" -> "1",
                   "goodsValue" -> "200.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "152.05",
@@ -654,14 +684,14 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
           List(
             Band("A",
               List(
-                Item("ALC/A1/CIDER", "250.10", None, Some(BigDecimal("2.00")), Calculation("0.00", "0.00", "0.00", "0.00"), Metadata("2 litres cider", "Cider", "300.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
+                Item("ALC/A1/CIDER", "250.10", None, Some(BigDecimal("2.00")), Calculation("0.00", "0.00", "0.00", "0.00"), Metadata("2 litres cider", "Cider", "300.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
               ),
               Calculation("0.00", "0.00", "0.00", "0.00")
             ),
             Band("B",
               List(
-                Item("ALC/A2/BEER", "304.11", None, Some(BigDecimal("3.00")), Calculation("74.00", "79.06", "91.43", "244.49"),Metadata("3 litres beer", "Beer", "400.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29"))),
-                Item("ALC/A3/WINE", "152.05", None, Some(BigDecimal("4.00")), Calculation("26.54", "113.88", "58.49", "198.91"), Metadata("4 litres wine", "Wine", "200.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
+                Item("ALC/A2/BEER", "304.11", None, Some(BigDecimal("3.00")), Calculation("74.00", "79.06", "91.43", "244.49"),Metadata("3 litres beer", "Beer", "400.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29"))),
+                Item("ALC/A3/WINE", "152.05", None, Some(BigDecimal("4.00")), Calculation("26.54", "113.88", "58.49", "198.91"), Metadata("4 litres wine", "Wine", "200.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
               ),
               Calculation("100.54", "192.94", "149.92", "443.40")
             )
@@ -672,14 +702,14 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
           List(
             Band("A",
               List(
-                Item("OGD/CLTHS/CHILD", "250.10", None, None, Calculation("0.00", "0.00", "0.00", "0.00"), Metadata("children's clothes", "Children's Clothes", "300.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
+                Item("OGD/CLTHS/CHILD", "250.10", None, None, Calculation("0.00", "0.00", "0.00", "0.00"), Metadata("children's clothes", "Children's Clothes", "300.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
               ),
               Calculation("0.00", "0.00", "0.00", "0.00")
             ),
             Band("B",
               List(
-                Item("OGD/BKS/MISC", "304.11", None, None, Calculation("74.00", "79.06", "91.43", "244.49"),Metadata("books or publications", "Books or Publications", "400.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29"))),
-                Item("OGD/BKS/MISC", "152.05", None, None, Calculation("26.54", "113.88", "58.49", "198.91"), Metadata("books or publications", "Books or Publications", "200.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
+                Item("OGD/BKS/MISC", "304.11", None, None, Calculation("74.00", "79.06", "91.43", "244.49"),Metadata("books or publications", "Books or Publications", "400.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29"))),
+                Item("OGD/BKS/MISC", "152.05", None, None, Calculation("26.54", "113.88", "58.49", "198.91"), Metadata("books or publications", "Books or Publications", "200.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
               ),
               Calculation("100.54", "192.94", "149.92", "443.40")
             )
@@ -690,14 +720,14 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
           List(
             Band("A",
               List(
-                Item("TOB/A1/CIGRT", "250.10", Some(200), None, Calculation("0.00", "0.00", "0.00", "0.00"), Metadata("200 cigarettes", "Cigarettes", "300.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
+                Item("TOB/A1/CIGRT", "250.10", Some(200), None, Calculation("0.00", "0.00", "0.00", "0.00"), Metadata("200 cigarettes", "Cigarettes", "300.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
               ),
               Calculation("0.00", "0.00", "0.00", "0.00")
             ),
             Band("B",
               List(
-                Item("TOB/A1/CIGRT", "304.11",Some(250),None, Calculation("74.00", "79.06", "91.43", "244.49"),Metadata("250 cigarettes", "Cigarettes", "400.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29"))),
-                Item("TOB/A1/HAND", "152.05",Some(0),Some(BigDecimal("0.12")), Calculation("26.54", "113.88", "58.49", "198.91"), Metadata("120g rolling tobacco", "Rolling Tobacco", "200.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
+                Item("TOB/A1/CIGRT", "304.11",Some(250),None, Calculation("74.00", "79.06", "91.43", "244.49"),Metadata("250 cigarettes", "Cigarettes", "400.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29"))),
+                Item("TOB/A1/HAND", "152.05",Some(0),Some(BigDecimal("0.12")), Calculation("26.54", "113.88", "58.49", "198.91"), Metadata("120g rolling tobacco", "Rolling Tobacco", "200.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
               ),
               Calculation("100.54", "192.94", "149.92", "443.40")
             )
@@ -729,7 +759,7 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
             "customerReference" -> Json.obj("idType" -> "passport", "idValue" -> "SX12345", "ukResident" -> false),
             "personalDetails" -> Json.obj("firstName" -> "Harry", "lastName" -> "Potter"),
             "contactDetails" -> Json.obj("emailAddress" -> "abc@gmail.com"),
-            "declarationHeader" -> Json.obj("portOfEntry" -> "LHR", "expectedDateOfArrival" -> "2018-05-31", "timeOfEntry" -> "13:20", "messageTypes" -> Json.obj("messageType" -> "DeclarationCreate"), "travellingFrom" -> "Great Britain", "onwardTravelGBNI" -> "NI", "uccRelief" -> true, "ukVATPaid" -> true, "ukExcisePaid" -> true),
+            "declarationHeader" -> Json.obj("portOfEntry" -> "LHR", "portOfEntryName" -> "LHR", "expectedDateOfArrival" -> "2018-05-31", "timeOfEntry" -> "13:20", "messageTypes" -> Json.obj("messageType" -> "DeclarationCreate"), "travellingFrom" -> "Great Britain", "onwardTravelGBNI" -> "NI", "uccRelief" -> true, "ukVATPaid" -> true, "ukExcisePaid" -> true),
             "declarationTobacco" -> Json.obj(
               "totalExciseTobacco" -> "100.54",
               "totalCustomsTobacco" -> "192.94",
@@ -740,7 +770,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "quantity" -> "200",
                   "goodsValue" -> "300.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "250.10",
@@ -754,7 +786,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "quantity" -> "250",
                   "goodsValue" -> "400.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "304.11",
@@ -768,7 +802,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "weight" -> "120.00",
                   "goodsValue" -> "200.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "152.05",
@@ -789,7 +825,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "volume" -> "2.00",
                   "goodsValue" -> "300.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "250.10",
@@ -803,7 +841,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "volume" -> "3.00",
                   "goodsValue" -> "400.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "304.11",
@@ -817,7 +857,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "volume" -> "4.00",
                   "goodsValue" -> "200.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "152.05",
@@ -838,7 +880,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "quantity" -> "1",
                   "goodsValue" -> "300.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "250.10",
@@ -852,7 +896,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "quantity" -> "1",
                   "goodsValue" -> "400.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "304.11",
@@ -866,7 +912,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "quantity" -> "1",
                   "goodsValue" -> "200.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "152.05",
@@ -909,14 +957,14 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
           List(
             Band("A",
               List(
-                Item("TOB/A1/CIGRT", "250.10", Some(200), None, Calculation("0.00", "0.00", "0.00", "0.00"), Metadata("200 cigarettes", "Cigarettes", "300.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
+                Item("TOB/A1/CIGRT", "250.10", Some(200), None, Calculation("0.00", "0.00", "0.00", "0.00"), Metadata("200 cigarettes", "Cigarettes", "300.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
               ),
               Calculation("0.00", "0.00", "0.00", "0.00")
             ),
             Band("B",
               List(
-                Item("TOB/A1/CIGRT", "304.11",Some(250),None, Calculation("74.00", "79.06", "91.43", "244.49"),Metadata("250 cigarettes", "Cigarettes", "400.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29"))),
-                Item("TOB/A1/HAND", "152.05",Some(0),Some(BigDecimal("0.12")), Calculation("26.54", "113.88", "58.49", "198.91"), Metadata("120g rolling tobacco", "Rolling Tobacco", "200.00",Currency("USD", "USA Dollar (USD)", Some("USD"), Nil), Country("US", "United States of America (the)", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
+                Item("TOB/A1/CIGRT", "304.11",Some(250),None, Calculation("74.00", "79.06", "91.43", "244.49"),Metadata("250 cigarettes", "Cigarettes", "400.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29"))),
+                Item("TOB/A1/HAND", "152.05",Some(0),Some(BigDecimal("0.12")), Calculation("26.54", "113.88", "58.49", "198.91"), Metadata("120g rolling tobacco", "Rolling Tobacco", "200.00",Currency("USD", "USA dollars (USD)", Some("USD"), Nil), Country("US", "United States of America", "US", isEu = false, Nil), ExchangeRate("1.2", "2018-10-29")))
               ),
               Calculation("100.54", "192.94", "149.92", "443.40")
             )
@@ -947,7 +995,7 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
             "customerReference" -> Json.obj("idType" -> "telephone", "idValue" -> "XPASSID7417532125", "ukResident" -> true),
             "personalDetails" -> Json.obj("firstName" -> "Harry", "lastName" -> "Potter"),
             "contactDetails" -> Json.obj(),
-            "declarationHeader" -> Json.obj("portOfEntry" -> "LHR", "expectedDateOfArrival" -> "2018-05-31", "timeOfEntry" -> "08:02", "messageTypes" -> Json.obj("messageType" -> "DeclarationCreate"), "travellingFrom" -> "Great Britain", "onwardTravelGBNI" -> "NI", "uccRelief" -> false, "ukVATPaid" -> true, "ukExcisePaid" -> false),
+            "declarationHeader" -> Json.obj("portOfEntry" -> "LHR", "portOfEntryName" -> "Heathrow Airport", "expectedDateOfArrival" -> "2018-05-31", "timeOfEntry" -> "08:02", "messageTypes" -> Json.obj("messageType" -> "DeclarationCreate"), "travellingFrom" -> "Great Britain", "onwardTravelGBNI" -> "NI", "uccRelief" -> false, "ukVATPaid" -> true, "ukExcisePaid" -> false),
             "declarationTobacco" -> Json.obj(
               "totalExciseTobacco" -> "100.54",
               "totalCustomsTobacco" -> "192.94",
@@ -958,7 +1006,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "quantity" -> "200",
                   "goodsValue" -> "300.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "250.10",
@@ -972,7 +1022,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "quantity" -> "250",
                   "goodsValue" -> "400.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "304.11",
@@ -986,7 +1038,9 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
                   "weight" -> "120.00",
                   "goodsValue" -> "200.00",
                   "valueCurrency" -> "USD",
+                  "valueCurrencyName" -> "USA dollars (USD)",
                   "originCountry" -> "US",
+                  "originCountryName" -> "United States of America",
                   "exchangeRate" -> "1.20",
                   "exchangeRateDate" -> "2018-10-29",
                   "goodsValueGBP" -> "152.05",


### PR DESCRIPTION
# PAS-1105

## New feature

Please include a summary / description of the change and which issue it fixes.  Include any relevant user needs, context or links to other PRs related to this PR (eg. acceptance tests, environment config).
1. Added new fields portOfEntryName, valueCurrencyName, originCountryName in the declaration json
2. Link to AT PR https://github.com/hmrc/bc-passengers-acceptance-tests/pull/168
3. Link to declarations PR https://github.com/hmrc/bc-passengers-declarations/pull/62

## PR Suggestions
- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
- Have you done a visual check of the changes?
- Is there any still commented or unused code? Lingering printlns?
- Have things been implemented in a complicated way?
- Are the test still over the coverage threshold?
- Does the compiler throw a lot of warnings? 
- Have methods and tests been named clearly?
- Were there any changes in the config? Do changes need to be made in app-config-???

## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [x]  I've added the links for relevant PRs for AT/PT in description

## Checklist PR Reviewer
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [x]  I've verified the links for relevant PRs for AT/PT in description before approval