### PR TITLE
PAS-1188: show timeout dialogue on first page

### DIFF
--- a/app/controllers/TravelDetailsController.scala
+++ b/app/controllers/TravelDetailsController.scala
@@ -82,7 +82,7 @@ class TravelDetailsController @Inject() (
       context.journeyData match {
         case Some(JourneyData(_, Some(countryCheck), _, _,_,_, _, _, _, _, _, _,_, _, _, _, _, _,_,_,_,_)) =>
             Ok(eu_country_check(EuCountryCheckDto.form.fill(EuCountryCheckDto(countryCheck)),
-              backLinkModel.backLink))
+              backLinkModel.backLink, timeout = true))
         case _ =>
             Ok(eu_country_check(EuCountryCheckDto.form, backLinkModel.backLink))
       }

--- a/app/views/travel_details/eu_country_check.scala.html
+++ b/app/views/travel_details/eu_country_check.scala.html
@@ -4,12 +4,12 @@
  *@
 
 @this(main_template: views.html.main_template, form: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF)
-@(f: Form[EuCountryCheckDto],backLink: Option[String])(implicit request: Request[_], messages: Messages)
+@(f: Form[EuCountryCheckDto],backLink: Option[String], timeout: Boolean = false)(implicit request: Request[_], messages: Messages)
 
 @import util.prefixErrorMessage
 
 
-@main_template(title = prefixErrorMessage(messages("heading.are_you_bringing_in_goods_from_"), f.hasErrors), timeout = false, backLink = backLink ) {
+@main_template(title = prefixErrorMessage(messages("heading.are_you_bringing_in_goods_from_"), f.hasErrors), timeout = timeout, backLink = backLink ) {
 
   @views.html.tags.errors(f)
 


### PR DESCRIPTION
# PAS-1188

## Bug fix

Service is not getting timed out on the first page.

No AT/PT is required

## PR Suggestions
- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
- Have you done a visual check of the changes?
- Is there any still commented or unused code? Lingering printlns?
- Have things been implemented in a complicated way?
- Are the test still over the coverage threshold?
- Does the compiler throw a lot of warnings? 
- Have methods and tests been named clearly?
- Were there any changes in the config? Do changes need to be made in app-config-???


## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [x]  I've added the links for relevant PRs for AT/PT in description

## Checklist PR Reviewer
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [ ]  I've verified the links for relevant PRs for AT/PT in description before approval