### PR TITLE
[PAS-1193] Redirect to start page when no journey data

### DIFF
--- a/app/controllers/enforce/JourneyEnforcer.scala
+++ b/app/controllers/enforce/JourneyEnforcer.scala
@@ -248,8 +248,8 @@ class DeclareAction @Inject()(appConfig: AppConfig, publicAction: PublicAction) 
     publicAction { implicit context =>
 
       if (context.journeyData.isDefined &&
-        (context.getJourneyData.calculatorResponse.fold(false)(x => BigDecimal(x.calculation.allTax) > 0 && BigDecimal(x.calculation.allTax) <=  appConfig.paymentLimit)) ||
-        (context.getJourneyData.euCountryCheck.getOrElse("") == "greatBritain" && context.getJourneyData.calculatorResponse.fold(false)(x => BigDecimal(x.calculation.allTax) == 0 && x.isAnyItemOverAllowance))
+        (context.getJourneyData.calculatorResponse.fold(false)(x => BigDecimal(x.calculation.allTax) > 0 && BigDecimal(x.calculation.allTax) <=  appConfig.paymentLimit) ||
+        (context.getJourneyData.euCountryCheck.getOrElse("") == "greatBritain" && context.getJourneyData.calculatorResponse.fold(false)(x => BigDecimal(x.calculation.allTax) == 0 && x.isAnyItemOverAllowance)))
       ){
         block(context)
       }

--- a/test/controllers/CalculateDeclareControllerSpec.scala
+++ b/test/controllers/CalculateDeclareControllerSpec.scala
@@ -197,6 +197,21 @@ class CalculateDeclareControllerSpec extends BaseSpec {
     }
   }
 
+  "Calling GET /check-tax-on-goods-you-bring-into-the-uk/declare-your-goods when there is no journey data" should {
+
+    "Display the declare-your-goods page" in new LocalSetup {
+      override lazy val cachedJourneyData: Future[Option[JourneyData]] = Future.successful(Option.empty)
+      override lazy val payApiResponse: PayApiServiceResponse = PayApiServiceFailureResponse
+      override lazy val declarationServiceResponse: DeclarationServiceResponse = DeclarationServiceSuccessResponse(ChargeReference("XJPR5768524625"))
+
+      val response: Future[Result] = route(app, EnhancedFakeRequest("GET", "/check-tax-on-goods-you-bring-into-the-uk/declare-your-goods")).get
+
+      status(response) shouldBe SEE_OTHER
+      redirectLocation(response) shouldBe Some("/check-tax-on-goods-you-bring-into-the-uk/where-goods-bought")
+    }
+  }
+
+
   "Calling GET /check-tax-on-goods-you-bring-into-the-uk/declare-your-goods when tax amount is 0.00" should {
 
     "Display the declare-your-goods page" in new LocalSetup {
@@ -205,6 +220,21 @@ class CalculateDeclareControllerSpec extends BaseSpec {
       override lazy val declarationServiceResponse: DeclarationServiceResponse = DeclarationServiceSuccessResponse(ChargeReference("XJPR5768524625"))
 
       val response: Future[Result] = route(app, EnhancedFakeRequest("GET", "/check-tax-on-goods-you-bring-into-the-uk/declare-your-goods")).get
+
+      status(response) shouldBe SEE_OTHER
+      redirectLocation(response) shouldBe Some("/check-tax-on-goods-you-bring-into-the-uk/where-goods-bought")
+    }
+  }
+
+  "Calling GET /check-tax-on-goods-you-bring-into-the-uk/user-information when there is no journey data" should {
+
+    "Display the where-goods-bought page" in new LocalSetup {
+
+      override lazy val cachedJourneyData: Future[Option[JourneyData]] = Future.successful(Option.empty)
+      override lazy val payApiResponse: PayApiServiceResponse = PayApiServiceFailureResponse
+      override lazy val declarationServiceResponse: DeclarationServiceResponse = DeclarationServiceSuccessResponse(ChargeReference("XJPR5768524625"))
+
+      val response: Future[Result] = route(app, EnhancedFakeRequest("GET", "/check-tax-on-goods-you-bring-into-the-uk/user-information")).get
 
       status(response) shouldBe SEE_OTHER
       redirectLocation(response) shouldBe Some("/check-tax-on-goods-you-bring-into-the-uk/where-goods-bought")


### PR DESCRIPTION
PAS-1193

Bug fix

Corrected condition in Journey Enforcer to redirect to start page when there is a user session and the declare goods page and user information pages have been accessed directly.

Also updated the Copyright comment in all files to be 2021

AT link: https://github.com/hmrc/bc-passengers-acceptance-tests/pull/172

## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [x]  I've added the links for relevant PRs for AT/PT in description

## Checklist PR Reviewer
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [x]  I've verified the links for relevant PRs for AT/PT in description before approval