### PR TITLE
PAS-1098: Format idValue to uppercase for ETMP

### DIFF
--- a/app/services/DeclarationService.scala
+++ b/app/services/DeclarationService.scala
@@ -95,7 +95,7 @@ class DeclarationService @Inject()(
       }
 
       Json.obj("idType" -> o.identificationType,
-        "idValue" -> getIdValue,
+        "idValue" -> getIdValue.toUpperCase,
         "ukResident" -> getBooleanValue(journeyData.isUKResident))
     })
 

--- a/test/services/DeclarationServiceSpec.scala
+++ b/test/services/DeclarationServiceSpec.scala
@@ -1008,6 +1008,67 @@ class DeclarationServiceSpec extends BaseSpec with ScalaFutures {
       )
     }
 
+    "format the idValue to uppercase if idType is telephone and contains lowercase characters in " in new LocalSetup {
+
+      override def journeyDataInCache: Option[JourneyData] = None
+
+      val jd: JourneyData = JourneyData(
+        euCountryCheck = Some("greatBritain"),
+        arrivingNICheck = Some(true),
+        isUKVatPaid = Some(true),
+        isUKExcisePaid = Some(false),
+        isUKResident = Some(true)
+      )
+
+      val userInformation: UserInformation = UserInformation("Harry", "Potter","telephone", "74a17b53c2125", "", "LHR", "", LocalDate.parse("2018-05-31"),  LocalTime.parse("8:2 am", DateTimeFormat.forPattern("hh:mm aa")))
+
+      val dm: JsObject = declarationService.buildPartialDeclarationMessage(
+        userInformation,
+        calculatorResponse,
+        jd,
+        "2018-05-31T12:14:08Z"
+      )
+
+      val idValue: String = dm.value.apply("simpleDeclarationRequest")
+        .\("requestDetail")
+        .\("customerReference")
+        .\("idValue").asOpt[String]
+        .getOrElse("")
+
+      idValue shouldEqual "XPASSID74A17B53C2125"
+
+    }
+
+    "format the idValue to uppercase if idType is not telephone and contains lowercase characters in " in new LocalSetup {
+
+      override def journeyDataInCache: Option[JourneyData] = None
+
+      val jd: JourneyData = JourneyData(
+        euCountryCheck = Some("greatBritain"),
+        arrivingNICheck = Some(true),
+        isUKVatPaid = Some(true),
+        isUKExcisePaid = Some(false),
+        isUKResident = Some(true)
+      )
+
+      val userInformation: UserInformation = UserInformation("Harry", "Potter","other", "74a17b53c2125", "", "LHR", "", LocalDate.parse("2018-05-31"),  LocalTime.parse("8:2 am", DateTimeFormat.forPattern("hh:mm aa")))
+
+      val dm: JsObject = declarationService.buildPartialDeclarationMessage(
+        userInformation,
+        calculatorResponse,
+        jd,
+        "2018-05-31T12:14:08Z"
+      )
+
+      val idValue: String = dm.value.apply("simpleDeclarationRequest")
+        .\("requestDetail")
+        .\("customerReference")
+        .\("idValue").asOpt[String]
+        .getOrElse("")
+
+      idValue shouldEqual "74A17B53C2125"
+    }
+
   }
 
   "Calling DeclarationService.storeChargeReference" should {


### PR DESCRIPTION
PAS-1098

Bug fix

Always persist idValue in uppercase to ensure uppercase values are sent to ETMP.

## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [ ]  I've added the links for relevant PRs for AT/PT in description

## Checklist PR Reviewer
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [ ]  I've verified the links for relevant PRs for AT/PT in description before approval