### PR TITLE
PAS-1206: VAT, Excise and Relief flags at item level on tell us page

### DIFF
--- a/app/controllers/DashboardController.scala
+++ b/app/controllers/DashboardController.scala
@@ -7,7 +7,7 @@ package controllers
 
 import config.AppConfig
 import connectors.Cache
-import controllers.enforce.{DashboardAction, PublicAction}
+import controllers.enforce.DashboardAction
 import javax.inject.{Inject, Singleton}
 import models.{ProductTreeLeaf, _}
 import play.api.i18n.{I18nSupport, MessagesApi}
@@ -15,7 +15,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services._
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 
 
@@ -29,9 +29,7 @@ class DashboardController @Inject() (
   val calculatorService: CalculatorService,
   val backLinkModel: BackLinkModel,
 
-  publicAction: PublicAction,
   dashboardAction: DashboardAction,
-
   val dashboard: views.html.purchased_products.dashboard,
 
   val error_template: views.html.error_template,
@@ -66,8 +64,11 @@ class DashboardController @Inject() (
 
         val showCalculate = !(alcoholPurchasedItemList.isEmpty && tobaccoPurchasedItemList.isEmpty && otherGoodsPurchasedItemList.isEmpty)
 
-        Ok(dashboard(jd, alcoholPurchasedItemList.reverse, tobaccoPurchasedItemList.reverse, otherGoodsPurchasedItemList.reverse, showCalculate, backLinkModel.backLink, appConfig.isIrishBorderQuestionEnabled))
-
+        Ok(dashboard(jd, alcoholPurchasedItemList.reverse, tobaccoPurchasedItemList.reverse, otherGoodsPurchasedItemList.reverse, showCalculate,
+          backLinkModel.backLink,
+          appConfig.isIrishBorderQuestionEnabled,
+          jd.euCountryCheck.contains("greatBritain") && jd.arrivingNICheck.contains(true),
+          jd.isUKResident.contains(true)))
       }
     }
   }

--- a/app/util.scala
+++ b/app/util.scala
@@ -140,6 +140,14 @@ package object util {
     }
   }
 
+  def formatYesNo(value: Boolean)(implicit messages: Messages) : String = {
+    if(value){
+      messages("label.yes")
+    } else {
+      messages("label.no")
+    }
+  }
+
   def prefixErrorMessage(title: String, hasError: Boolean)(implicit messages: Messages): String = {
     if(hasError) {
       messages("label.error") + " " + title

--- a/app/views/purchased_products/dashboard.scala.html
+++ b/app/views/purchased_products/dashboard.scala.html
@@ -10,7 +10,9 @@
   otherGoodsPurchasedItemList: List[PurchasedItem],
   showCalculate: Boolean,
   backLink: Option[String],
-  isIrishBorderQuestionEnabled: Boolean
+  isIrishBorderQuestionEnabled: Boolean,
+  isGbNi: Boolean,
+  isUkResident: Boolean
 )(implicit request: Request[_], messages: Messages)
 
 @import uk.gov.hmrc.play.views.html._
@@ -52,6 +54,20 @@
                 @purchasedItem.purchasedProductInstance.cost.map(c => formatMonetaryValue(c)) @messages(purchasedItem.displayCurrency)
               </dd>
             </div>
+            @if(isGbNi) {
+              <div class="vat-paid">
+                <dt class="cya-question">@messages("label.vat_paid")</dt>
+                <dd class="cya-answer">
+                @purchasedItem.purchasedProductInstance.isVatPaid.map(formatYesNo)
+                </dd>
+              </div>
+              <div class="excise-paid">
+                <dt class="cya-question">@messages("label.excise_paid")</dt>
+                <dd class="cya-answer">
+                @purchasedItem.purchasedProductInstance.isExcisePaid.map(formatYesNo)
+                </dd>
+              </div>
+            }
           </dl>
           <div class="margin-bottom-20">
             <a href="@routes.AlcoholInputController.displayEditForm(purchasedItem.purchasedProductInstance.iid)">@messages("label.edit_this_item") <span class="visually-hidden">@description</span></a>
@@ -96,6 +112,21 @@
                 @purchasedItem.purchasedProductInstance.cost.map(c => formatMonetaryValue(c)) @messages(purchasedItem.displayCurrency)
               </dd>
             </div>
+
+            @if(isGbNi) {
+              <div class="vat-paid">
+                <dt class="cya-question">@messages("label.vat_paid")</dt>
+                <dd class="cya-answer">
+                @purchasedItem.purchasedProductInstance.isVatPaid.map(formatYesNo)
+                </dd>
+              </div>
+              <div class="excise-paid">
+                <dt class="cya-question">@messages("label.excise_paid")</dt>
+                <dd class="cya-answer">
+                @purchasedItem.purchasedProductInstance.isExcisePaid.map(formatYesNo)
+                </dd>
+              </div>
+            }
           </dl>
           <div class="margin-bottom-20">
             <a href="@routes.TobaccoInputController.displayEditForm(purchasedItem.purchasedProductInstance.iid)">@messages("label.edit_this_item") <span class="visually-hidden">@description</span></a>
@@ -145,6 +176,22 @@
                 @purchasedItem.purchasedProductInstance.cost.map(c => formatMonetaryValue(c)) @messages(purchasedItem.displayCurrency)
             </dd>
           </div>
+          @if(isGbNi) {
+            <div class="vat-paid">
+              <dt class="cya-question">@messages("label.vat_paid")</dt>
+              <dd class="cya-answer">
+              @purchasedItem.purchasedProductInstance.isVatPaid.map(formatYesNo)
+              </dd>
+            </div>
+            @if(!isUkResident) {
+              <div class="tax-exempt">
+                <dt class="cya-question">@messages("label.tax_exempt")</dt>
+                <dd class="cya-answer">
+                @purchasedItem.purchasedProductInstance.isUccRelief.map(formatYesNo)
+                </dd>
+              </div>
+            }
+          }
         </dl>
         <div class="margin-bottom-20">
           <a href="@routes.OtherGoodsInputController.displayEditForm(purchasedItem.purchasedProductInstance.iid)">@messages("label.edit_this_item") <span class="visually-hidden">@description</span></a>

--- a/conf/messages
+++ b/conf/messages
@@ -1676,3 +1676,7 @@ head.error.required.identification_number_previous = Enter the identification nu
 head.error.required.referenceNumber = Enter your reference number
 head.error.referenceNumber.invalid = Enter your reference number in the correct format
 error.referenceNumber.invalid = Enter your reference number in the correct format
+
+label.vat_paid = VAT paid
+label.excise_paid = Excise paid
+label.tax_exempt = Tax exempt

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1676,3 +1676,7 @@ head.error.required.identification_number_previous = (W)Enter the identification
 head.error.required.referenceNumber = (W)Enter your reference number
 head.error.referenceNumber.invalid = (W)Enter your reference number in the correct format
 error.referenceNumber.invalid = (W)Enter your reference number in the correct format
+
+label.vat_paid = (W)VAT paid(W)
+label.excise_paid = (W)Excise paid(W)
+label.tax_exempt = (W)Tax exempt(W)


### PR DESCRIPTION
PAS-1206

New feature 
VAT, Excise and Relief flags at item level on tell us page

## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [ ]  I've added the links for relevant PRs for AT/PT in description

## Checklist PR Reviewer
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [ ]  I've verified the links for relevant PRs for AT/PT in description before approval