### PR TITLE
PAS-1090: reset journey data if the ukresidency answer is changed

### DIFF
--- a/app/controllers/CalculateDeclareController.scala
+++ b/app/controllers/CalculateDeclareController.scala
@@ -160,15 +160,7 @@ class CalculateDeclareController @Inject()(
   }
 
   def calculate: Action[AnyContent] = dashboardAction { implicit context =>
-
-    if (context.getJourneyData.euCountryCheck.contains("greatBritain")) {
-      val updatedJourneyData = context.getJourneyData.copy(purchasedProductInstances = context.getJourneyData.purchasedProductInstances
-        .map(product => product.copy(isCustomPaid = context.getJourneyData.isUKResident)))
-      cache.store(updatedJourneyData).flatMap(_ =>
-        doCalculateAction(updatedJourneyData))
-    } else {
       doCalculateAction(context.getJourneyData)
-    }
   }
 
   private def doCalculateAction(journeyData: JourneyData)(implicit context: LocalContext): Future[Result] = {

--- a/app/services/TravelDetailsService.scala
+++ b/app/services/TravelDetailsService.scala
@@ -223,9 +223,13 @@ class TravelDetailsService @Inject() (
     journeyData match {
       case Some(journeyData) if !journeyData.isUKResident.contains(isUKResident) =>
 
-        cache.storeJourneyData(journeyData.copy(
-          isUKResident = Some(isUKResident)
-        ))
+        val resetJourneyData = JourneyData(
+          isUKResident = Some(isUKResident),
+          euCountryCheck = journeyData.euCountryCheck,
+          arrivingNICheck = journeyData.arrivingNICheck
+        )
+
+        cache.storeJourneyData(resetJourneyData)
 
       case None =>
         cache.storeJourneyData( JourneyData(isUKResident = Some(isUKResident)) )

--- a/test/services/TravelDetailsServiceSpec.scala
+++ b/test/services/TravelDetailsServiceSpec.scala
@@ -282,14 +282,15 @@ class TravelDetailsServiceSpec extends BaseSpec {
       verify(cacheMock, times(0)).storeJourneyData(any())(any())
     }
 
-    "store isUKResident when journey data does exist, keeping existing journey data if the isUKResident has changed" in new LocalSetup {
+    "store isUKResident when journey data does exist, reset existing journey data if the isUKResident has changed" in new LocalSetup {
 
-      val journeyData: Option[JourneyData] = Some(JourneyData(isUKVatExcisePaid = Some(true), isUKResident = Some(false)))
+      val ppi = PurchasedProductInstance(iid = "someId", path = ProductPath("alcohol/beer"), isVatPaid = Some(true))
+      val journeyData: Option[JourneyData] = Some(JourneyData(isUKVatExcisePaid = Some(true), euCountryCheck = Some("greatBritain"), arrivingNICheck = Some(true), isUKResident = Some(false), purchasedProductInstances = List(ppi), bringingOverAllowance = Some(true)))
 
       await(travelDetailsService.storeUKResident(journeyData)(isUKResident = true))
 
       verify(cacheMock, times(1)).storeJourneyData(
-        meq(JourneyData(isUKVatExcisePaid = Some(true), isUKResident = Some(true))))(any())
+        meq(JourneyData(euCountryCheck = Some("greatBritain"), arrivingNICheck = Some(true), isUKResident = Some(true))))(any())
     }
   }
 


### PR DESCRIPTION
# PAS-1090

Bug fix

Remove product information if the user changes UK residency answer in GBNI journey.
No ATs/PTs.

## PR Suggestions
- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
- Have you done a visual check of the changes?
- Is there any still commented or unused code? Lingering printlns?
- Have things been implemented in a complicated way?
- Are the test still over the coverage threshold?
- Does the compiler throw a lot of warnings? 
- Have methods and tests been named clearly?
- Were there any changes in the config? Do changes need to be made in app-config-???


## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [x]  I've added the links for relevant PRs for AT/PT in description

## Checklist PR Reviewer
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [ ]  I've verified the links for relevant PRs for AT/PT in description before approval