### PR TITLE
PAS-1228 PAS-1230: Remove working instances on cancel and direct dash…

### DIFF
--- a/app/controllers/SelectProductController.scala
+++ b/app/controllers/SelectProductController.scala
@@ -38,6 +38,12 @@ class SelectProductController @Inject()(
   implicit val ec: ExecutionContext
 ) extends FrontendController(controllerComponents) with I18nSupport with ControllerHelpers {
 
+  def cancel():  Action[AnyContent] = dashboardAction { implicit context =>
+    revertWorkingInstance {
+      Future.successful(Redirect(routes.SelectProductController.nextStep()))
+    }
+  }
+
   def nextStep(): Action[AnyContent] = dashboardAction { implicit context =>
 
     withNextSelectedProductAlias {

--- a/app/models/JourneyData.scala
+++ b/app/models/JourneyData.scala
@@ -126,6 +126,21 @@ case class JourneyData(
     val newPdList = block(getOrCreatePurchasedProductInstance(path, iid)) :: purchasedProductInstances.filterNot(_.path == path)
     this.copy(purchasedProductInstances = newPdList)
   }
+  def revertPurchasedProductInstance(): JourneyData = {
+    val workingInstance = this.workingInstance
+    if(workingInstance.isDefined){
+      val ppis = this.purchasedProductInstances.map(ppi => {
+        if(ppi.iid == workingInstance.get.iid){
+          workingInstance.get
+        }else{
+          ppi
+        }
+      })
+      this.copy(purchasedProductInstances = ppis)
+    }else{
+      this
+    }
+  }
 
   def removePurchasedProductInstance(iid: String): JourneyData = {
     this.copy(purchasedProductInstances = purchasedProductInstances.filterNot(_.iid==iid))

--- a/app/services/CalculatorService.scala
+++ b/app/services/CalculatorService.scala
@@ -99,9 +99,9 @@ class CalculatorService @Inject() (
   }
 
   def journeyDataToLimitsRequest(journeyData: JourneyData)(implicit hc: HeaderCarrier): Option[LimitRequest] = {
-
       val speculativeItems: List[SpeculativeItem] = for {
-        purchasedProductInstance <- journeyData.workingInstance.fold(journeyData.purchasedProductInstances)(wi => wi :: journeyData.purchasedProductInstances.filter(_.iid != wi.iid))
+
+        purchasedProductInstance <- journeyData.purchasedProductInstances
         productTreeLeaf <- productTreeService.productTree.getDescendant(purchasedProductInstance.path).collect { case p: ProductTreeLeaf => p }
       } yield SpeculativeItem(purchasedProductInstance, productTreeLeaf, 0)
 

--- a/app/services/NewPurchaseService.scala
+++ b/app/services/NewPurchaseService.scala
@@ -26,6 +26,8 @@ class NewPurchaseService @Inject() (
     } yield PurchasedProductInstance(path, iid, weightOrVolume, noOfSticks, country, countryEU, Some(currency), Some(cost), isCustomPaid = Some(isCustomsExempt(journeyData.euCountryCheck, originCountryCode, journeyData.isUKResident)))
 
     (journeyData.copy(purchasedProductInstances = journeyData.purchasedProductInstances ++ dataToAdd,
+      //Added partial working instance to differenciate between new item and existing in ControllerHelpers.revertWorkingInstance
+      workingInstance = Some(PurchasedProductInstance(dataToAdd.head.path,dataToAdd.head.iid)),
       defaultCountry = Some(countryCode),
       defaultOriginCountry = Some(originCountryCode.getOrElse("")),
       defaultCurrency = Some(currency)),iid)

--- a/app/services/SelectProductService.scala
+++ b/app/services/SelectProductService.scala
@@ -43,7 +43,7 @@ class SelectProductService @Inject()(
   }
 
   def removeSelectedAlias(journeyData: JourneyData)(implicit hc: HeaderCarrier): Future[JourneyData] = {
-    cache.store(journeyData.copy(selectedAliases = journeyData.selectedAliases.tail))
+    cache.store(journeyData.copy(workingInstance = None, selectedAliases = journeyData.selectedAliases.tail))
   }
 
 

--- a/app/views/alcohol/alcohol_input.scala.html
+++ b/app/views/alcohol/alcohol_input.scala.html
@@ -95,7 +95,7 @@
     </div>
 
     <div class="form-group">
-      <a href="@routes.SelectProductController.nextStep">@messages("label.cancel")</a>
+      <a href="@routes.SelectProductController.cancel">@messages("label.cancel")</a>
     </div>
 
   }

--- a/app/views/other_goods/other_goods_input.scala.html
+++ b/app/views/other_goods/other_goods_input.scala.html
@@ -122,7 +122,7 @@
     </div>
 
     <div class="form-group">
-      <a href="@routes.SelectProductController.nextStep">@messages("label.cancel")</a>
+      <a href="@routes.SelectProductController.cancel">@messages("label.cancel")</a>
     </div>
 
   }

--- a/app/views/tobacco/tobacco_input.scala.html
+++ b/app/views/tobacco/tobacco_input.scala.html
@@ -92,7 +92,7 @@
     </div>
 
     <div class="form-group">
-      <a href="@routes.SelectProductController.nextStep">@messages("label.cancel")</a>
+      <a href="@routes.SelectProductController.cancel">@messages("label.cancel")</a>
     </div>
 
   }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -74,6 +74,7 @@ GET        /remove-goods/$path<.+>/:iid/remove                                  
 POST       /remove-goods/$path<.+>/:iid/remove                                         controllers.AlterProductsController.remove(path: ProductPath, iid: String)
 
 GET        /select-goods/next-step                                                     controllers.SelectProductController.nextStep
+GET        /select-goods/cancel                                                        controllers.SelectProductController.cancel
 
 GET        /enter-goods/$path<alcohol/.+>/tell-us                                      controllers.AlcoholInputController.displayAddForm(path: ProductPath)
 POST       /enter-goods/$path<alcohol/.+>/tell-us                                      controllers.AlcoholInputController.processAddForm(path: ProductPath)

--- a/test/controllers/AlcoholInputControllerSpec.scala
+++ b/test/controllers/AlcoholInputControllerSpec.scala
@@ -637,7 +637,7 @@ class AlcoholInputControllerSpec extends BaseSpec {
         meq(BigDecimal(50.00))
       )(any())
 
-      verify(injected[Cache], times(1)).store(any())(any())
+      verify(injected[Cache], times(2)).store(any())(any())
     }
 
     "modify the relevant PPI in the JourneyData and redirect to UK VAT Paid page for GBNI Journey" in new LocalSetup {

--- a/test/controllers/OtherGoodsInputControllerSpec.scala
+++ b/test/controllers/OtherGoodsInputControllerSpec.scala
@@ -571,7 +571,7 @@ class OtherGoodsInputControllerSpec extends BaseSpec {
         meq(BigDecimal(12.12))
       )(any())
 
-      verify(injected[Cache], times(1)).store(any())(any())
+      verify(injected[Cache], times(2)).store(any())(any())
     }
 
     "modify a PPI in the JourneyData and redirect to UKVatPaid page when GBNI journey" in new LocalSetup {

--- a/test/controllers/TobaccoInputControllerSpec.scala
+++ b/test/controllers/TobaccoInputControllerSpec.scala
@@ -1297,7 +1297,7 @@ class TobaccoInputControllerSpec extends BaseSpec {
         meq(BigDecimal(98.00))
       )(any())
 
-      verify(injected[Cache], times(1)).store(any())(any())
+      verify(injected[Cache], times(2)).store(any())(any())
     }
 
     "modify a PPI in the JourneyData and redirect to UKVatPaid page when GBNI journey" in new LocalSetup {


### PR DESCRIPTION
PAS-1228 and PAS-1230

Bug fix / New feature (delete as appropriate)
PT PR: https://github.com/hmrc/bc-passengers-performance-tests/pull/43

When cancelling out of changes made for Editing a product, the changes were not being reverted. Also removed incomplete products from Dashboard when a user navigates away from the screen when they are in the middle of adding or editing a product

## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [ ]  I've added the links for relevant PRs for AT/PT in description

## Checklist PR Reviewer
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [x]  I've verified the links for relevant PRs for AT/PT in description before approval