### PR TITLE
PAS-1245: populate user information page when data is in db

### DIFF
--- a/app/controllers/CalculateDeclareController.scala
+++ b/app/controllers/CalculateDeclareController.scala
@@ -77,9 +77,20 @@ class CalculateDeclareController @Inject()(
   }
 
   def enterYourDetails: Action[AnyContent] = declareAction { implicit context =>
-    context.getJourneyData.euCountryCheck match {
-      case Some("greatBritain") => Future.successful(Ok(enter_your_details(EnterYourDetailsDto.form(receiptDateTime), portsOfArrivalService.getAllPortsNI, context.getJourneyData.euCountryCheck, backLinkModel.backLink)))
-      case _ => Future.successful(Ok(enter_your_details(EnterYourDetailsDto.form(receiptDateTime), portsOfArrivalService.getAllPorts, context.getJourneyData.euCountryCheck, backLinkModel.backLink)))
+    context.getJourneyData.userInformation match {
+
+      case Some(userInformation) => {
+        context.getJourneyData.euCountryCheck match {
+          case Some("greatBritain") => Future.successful(Ok(enter_your_details(EnterYourDetailsDto.form(receiptDateTime).fill(EnterYourDetailsDto.fromUserInformation(userInformation)), portsOfArrivalService.getAllPortsNI, context.getJourneyData.euCountryCheck, backLinkModel.backLink) ) )
+          case _ => Future.successful(Ok(enter_your_details(EnterYourDetailsDto.form(receiptDateTime).fill(EnterYourDetailsDto.fromUserInformation(userInformation)), portsOfArrivalService.getAllPorts, context.getJourneyData.euCountryCheck, backLinkModel.backLink)))
+        }
+      }
+      case _ => {
+        context.getJourneyData.euCountryCheck match {
+          case Some("greatBritain") => Future.successful(Ok(enter_your_details(EnterYourDetailsDto.form(receiptDateTime), portsOfArrivalService.getAllPortsNI, context.getJourneyData.euCountryCheck, backLinkModel.backLink)))
+          case _ => Future.successful(Ok(enter_your_details(EnterYourDetailsDto.form(receiptDateTime), portsOfArrivalService.getAllPorts, context.getJourneyData.euCountryCheck, backLinkModel.backLink)))
+        }
+      }
     }
   }
 

--- a/app/models/JourneyData.scala
+++ b/app/models/JourneyData.scala
@@ -41,8 +41,8 @@ object UserInformation {
       dto.identification.identificationNumber ,
       dto.emailAddress.email,dto.placeOfArrival.selectPlaceOfArrival.getOrElse(""),
       dto.placeOfArrival.enterPlaceOfArrival.getOrElse(""),
-      dto.dateTimeOfArrival.dateOfArrival,
-      dto.dateTimeOfArrival.timeOfArrival)
+      new LocalDate(dto.dateTimeOfArrival.dateOfArrival),
+      LocalTime.parse(dto.dateTimeOfArrival.timeOfArrival, org.joda.time.format.DateTimeFormat.forPattern("hh:mm aa")))
 }
 case class UserInformation(
   firstName: String,

--- a/test/controllers/CalculateDeclareControllerSpec.scala
+++ b/test/controllers/CalculateDeclareControllerSpec.scala
@@ -328,6 +328,54 @@ class CalculateDeclareControllerSpec extends BaseSpec {
 
         doc.getElementsByTag("h1").text() shouldBe "Enter your details"
       }
+
+      "populate user-information page if user-information data is present in db" in new LocalSetup {
+        override lazy val cachedJourneyData: Future[Option[JourneyData]] = Future.successful(Some(JourneyData(euCountryCheck = Some("nonEuOnly"), isVatResClaimed = None, isBringingDutyFree = None, bringingOverAllowance = Some(true), ageOver17 = Some(true), privateCraft = Some(false), userInformation = Some(ui), calculatorResponse = Some(crWithinLimitLow))))
+        override lazy val payApiResponse: PayApiServiceResponse = PayApiServiceFailureResponse
+        override lazy val declarationServiceResponse: DeclarationServiceResponse = DeclarationServiceSuccessResponse(ChargeReference("XJPR5768524625"))
+
+        val response: Future[Result] = route(app, EnhancedFakeRequest("GET", "/check-tax-on-goods-you-bring-into-the-uk/user-information")).get
+
+
+        val content: String = contentAsString(response)
+        val doc: Document = Jsoup.parse(content)
+
+        doc.getElementsByTag("h1").text() shouldBe "Enter your details"
+        doc.getElementById("firstName").`val`() shouldBe "Harry"
+        doc.getElementById("lastName").`val`() shouldBe "Potter"
+        doc.getElementById("identification.identificationNumber").`val`() shouldBe "SX12345"
+        doc.getElementById("emailAddress.email").`val`() shouldBe "abc@gmail.com"
+        doc.getElementById("dateTimeOfArrival.dateOfArrival.day").`val`() shouldBe "12"
+        doc.getElementById("dateTimeOfArrival.dateOfArrival.month").`val`() shouldBe "11"
+        doc.getElementById("dateTimeOfArrival.dateOfArrival.year").`val`() shouldBe "2018"
+        doc.getElementById("dateTimeOfArrival.timeOfArrival.hour").`val`() shouldBe "12"
+        doc.getElementById("dateTimeOfArrival.timeOfArrival.minute").`val`() shouldBe "20"
+        doc.getElementById("am_pm").getElementsByAttribute("selected").`val`() shouldBe "pm"
+      }
+
+      "populate user-information page if user-information data is present in db for GB NI journey" in new LocalSetup {
+        override lazy val cachedJourneyData: Future[Option[JourneyData]] = Future.successful(Some(JourneyData(euCountryCheck = Some("greatBritain"), isVatResClaimed = None, isBringingDutyFree = None, bringingOverAllowance = Some(true), ageOver17 = Some(true), privateCraft = Some(false), userInformation = Some(ui), calculatorResponse = Some(crWithinLimitLow))))
+        override lazy val payApiResponse: PayApiServiceResponse = PayApiServiceFailureResponse
+        override lazy val declarationServiceResponse: DeclarationServiceResponse = DeclarationServiceSuccessResponse(ChargeReference("XJPR5768524625"))
+
+        val response: Future[Result] = route(app, EnhancedFakeRequest("GET", "/check-tax-on-goods-you-bring-into-the-uk/user-information")).get
+
+
+        val content: String = contentAsString(response)
+        val doc: Document = Jsoup.parse(content)
+
+        doc.getElementsByTag("h1").text() shouldBe "Enter your details"
+        doc.getElementById("firstName").`val`() shouldBe "Harry"
+        doc.getElementById("lastName").`val`() shouldBe "Potter"
+        doc.getElementById("identification.identificationNumber").`val`() shouldBe "SX12345"
+        doc.getElementById("emailAddress.email").`val`() shouldBe "abc@gmail.com"
+        doc.getElementById("dateTimeOfArrival.dateOfArrival.day").`val`() shouldBe "12"
+        doc.getElementById("dateTimeOfArrival.dateOfArrival.month").`val`() shouldBe "11"
+        doc.getElementById("dateTimeOfArrival.dateOfArrival.year").`val`() shouldBe "2018"
+        doc.getElementById("dateTimeOfArrival.timeOfArrival.hour").`val`() shouldBe "12"
+        doc.getElementById("dateTimeOfArrival.timeOfArrival.minute").`val`() shouldBe "20"
+        doc.getElementById("am_pm").getElementsByAttribute("selected").`val`() shouldBe "pm"
+      }
     }
 
     "Calling GET /check-tax-on-goods-you-bring-into-the-uk/declare-your-goods with tax greater than £90,000" should {


### PR DESCRIPTION
# PAS-1245

## Bug fix

Populate user information page from database when coming back from OPS.
No ATs/PTs required

## PR Suggestions
- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
- Have you done a visual check of the changes?
- Is there any still commented or unused code? Lingering printlns?
- Have things been implemented in a complicated way?
- Are the test still over the coverage threshold?
- Does the compiler throw a lot of warnings? 
- Have methods and tests been named clearly?
- Were there any changes in the config? Do changes need to be made in app-config-???


## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [x]  I've added the links for relevant PRs for AT/PT in description

## Checklist PR Reviewer
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [ ]  I've verified the links for relevant PRs for AT/PT in description before approval