### PR TITLE
PAS-1259: Wrong label displayed in tell us page for heated tobacco

### DIFF
--- a/conf/messages
+++ b/conf/messages
@@ -256,6 +256,7 @@ label.tobacco.cigars.single = Cigar
 label.tobacco.chewing-tobacco = Pipe or chewing tobacco
 label.tobacco.rolling-tobacco = Rolling tobacco
 label.tobacco.heated-tobacco = Heated tobacco
+label.tobacco.heated-tobacco.single = Heated tobacco
 label.total_number_of_tobacco.cigarettes = Total number of cigarettes
 label.total_number_of_tobacco.heated-tobacco = Total number of units of heated tobacco
 label.total_number_of_tobacco.cigarillos = Total number of cigarillos

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -256,6 +256,7 @@ label.tobacco.cigars.single=Sigâr
 label.tobacco.chewing-tobacco=Tybaco cetyn neu gnoi
 label.tobacco.rolling-tobacco=Tybaco rholio
 label.tobacco.heated-tobacco=Tybaco gwresogi nid llosgi
+label.tobacco.heated-tobacco.single=Tybaco gwresogi nid llosgi
 label.total_number_of_tobacco.cigarettes=Cyfanswm y sigaréts
 label.total_number_of_tobacco.cigarillos=Cyfanswm y sigarilos
 label.total_number_of_tobacco.cigars=Cyfanswm y sigârs


### PR DESCRIPTION
# PAS-1259

##  New feature

1. Wrong label displayed in tell us page for heated tobacco.
2. Link to AT/PT >> Not applicable.

## PR Suggestions
- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
- Have you done a visual check of the changes?
- Is there any still commented or unused code? Lingering printlns?
- Have things been implemented in a complicated way?
- Are the test still over the coverage threshold?
- Does the compiler throw a lot of warnings? 
- Have methods and tests been named clearly?
- Were there any changes in the config? Do changes need to be made in app-config-???


## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [ ]  I've added the links for relevant PRs for AT/PT in description

## Checklist PR Reviewer
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [ ]  I've verified the links for relevant PRs for AT/PT in description before approval