### PR TITLE
PAS-1323:Stop Showing N/A in Service

### DIFF
--- a/app/services/PayApiService.scala
+++ b/app/services/PayApiService.scala
@@ -55,7 +55,7 @@ class PayApiService @Inject()(
           messages("label.no")
         }
       } else {
-        messages("label.na")
+        messages("label.not_required")
       }
     }
 

--- a/conf/messages
+++ b/conf/messages
@@ -1648,7 +1648,8 @@ label.amount_due = Amount due
 label.amount_paid_previously = Amount paid previously
 label.total_due_now = Total due now
 label.total_paid_now = Total paid now
-label.na = N/A
+label.na = Unknown
+label.not_required = Not required
 
 #declaration not found page
 heading.declaration_not_found = Your declaration cannot be found

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1648,7 +1648,8 @@ label.amount_due = Swm sy’n ddyledus
 label.amount_paid_previously =Swm a dalwyd yn flaenorol
 label.total_due_now =Cyfanswm sy’n ddyledus nawr
 label.total_paid_now = Cyfanswm wedi’i dalu nawr
-label.na = N/A
+label.na = Anhysbys
+label.not_required = Ddim yn ofynnol
 
 #declaration not found page
 heading.declaration_not_found = Ni ellir canfod eich datganiad

--- a/test/services/PayApiServiceSpec.scala
+++ b/test/services/PayApiServiceSpec.scala
@@ -63,7 +63,7 @@ class PayApiServiceSpec extends BaseSpec {
        |            "price": "120.00 USA dollars (USD)",
        |            "purchaseLocation": "United States of America",
        |            "producedIn" : "Algeria",
-       |            "evidenceOfOrigin" : "N/A"
+       |            "evidenceOfOrigin" : "Not required"
        |        },
        |        {
        |            "name": "250 cigarettes",
@@ -78,8 +78,8 @@ class PayApiServiceSpec extends BaseSpec {
        |            "costInGbp": "198.91",
        |            "price": "200.00 USA dollars (USD)",
        |            "purchaseLocation": "United States of America",
-       |            "producedIn" : "N/A",
-       |            "evidenceOfOrigin" : "N/A"
+       |            "producedIn" : "Unknown",
+       |            "evidenceOfOrigin" : "Not required"
        |        },
        |        {   "name": "Televisions",
        |            "costInGbp": "0.00",
@@ -123,7 +123,7 @@ class PayApiServiceSpec extends BaseSpec {
        |            "price": "120.00 USA dollars (USD)",
        |            "purchaseLocation": "United States of America",
        |            "producedIn" : "Algeria",
-       |            "evidenceOfOrigin" : "N/A"
+       |            "evidenceOfOrigin" : "Not required"
        |        },
        |        {
        |            "name": "250 cigarettes",
@@ -138,8 +138,8 @@ class PayApiServiceSpec extends BaseSpec {
        |            "costInGbp": "198.91",
        |            "price": "200.00 USA dollars (USD)",
        |            "purchaseLocation": "United States of America",
-       |            "producedIn" : "N/A",
-       |            "evidenceOfOrigin" : "N/A"
+       |            "producedIn" : "Unknown",
+       |            "evidenceOfOrigin" : "Not required"
        |        },
        |        {   "name": "Televisions",
        |            "costInGbp": "0.00",


### PR DESCRIPTION
# PAS-1323
## Bug fix 

Stop Showing N/A in Service
AT Link: N/A

## PR Suggestions
- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
- Have you done a visual check of the changes?
- Is there any still commented or unused code? Lingering printlns?
- Have things been implemented in a complicated way?
- Are the test still over the coverage threshold?
- Does the compiler throw a lot of warnings? 
- Have methods and tests been named clearly?
- Were there any changes in the config? Do changes need to be made in app-config-???


## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [x]  I've added the links for relevant PRs for AT/PT in description

## Checklist PR Reviewer
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 - [ ]  I've verified the links for relevant PRs for AT/PT in description before approval