### PR TITLE
DDCE-4227: Warning text correction on upper-limits page

### DIFF
--- a/app/views/components/warning.scala.html
+++ b/app/views/components/warning.scala.html
@@ -16,12 +16,12 @@
 
 @this()
 
-@(content: Html)
+@(content: Html)(implicit messages: Messages)
 
 <div class="govuk-warning-text">
  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
  <strong class="govuk-warning-text__text">
-  <span class="govuk-warning-text__assistive">@content</span>
+  <span class="govuk-warning-text__assistive">@messages("site.warning")</span>
   @content
  </strong>
 </div>

--- a/conf/messages
+++ b/conf/messages
@@ -1709,6 +1709,7 @@ error.summary.title = There is a problem
 error.browser.title.prefix = Error:
 
 site.govuk = GOV.UK
+site.warning = Warning
 
 time.period.am = am
 time.period.pm = pm

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1709,6 +1709,7 @@ error.summary.title = Mae problem wedi codi
 error.browser.title.prefix = Gwall:
 
 site.govuk = GOV.UK/CYMRAEG
+site.warning = Rhybudd
 
 time.period.am = am
 time.period.pm = pm


### PR DESCRIPTION
### DDCE-4227: Warning text correction on upper-limits page

Fixed issue raised in accessibility audit https://github.com/hmrc/accessibility-audits-external/issues/2543
Dependencies and cleanup left as being done on DDCE-3017 & DDCE-4220
Used welsh translation from another DDCE service https://github.com/hmrc/binding-tariff-trader-frontend/blob/bb24a104b2635a7218284311d33f4ca9d67c4a03/conf/messages.cy#L67 as it is generic.