### PR TITLE
DDCE-4964 Content change for limit exceeded page.

### DIFF
--- a/app/controllers/LimitExceedController.scala
+++ b/app/controllers/LimitExceedController.scala
@@ -19,13 +19,13 @@ package controllers
 import config.AppConfig
 import connectors.Cache
 import controllers.enforce.LimitExceedAction
-import javax.inject.Inject
-import models.ProductPath
+import models._
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.{CalculatorService, ProductTreeService}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class LimitExceedController @Inject() (
@@ -43,11 +43,10 @@ class LimitExceedController @Inject() (
     with I18nSupport
     with ControllerHelpers {
 
-  def loadLimitExceedPage(path: ProductPath): Action[AnyContent] = limitExceedAction { implicit context =>
-    requireProduct(path) { product =>
-      Future.successful(
-        Ok(limitExceedPage(product.name, s"heading.${product.applicableLimits.last.toLowerCase}.limit-exceeded"))
-      )
+  def loadLimitExceedPage(path: ProductPath, weightOrVolume: String): Action[AnyContent] =
+    limitExceedAction { implicit context =>
+      requireProduct(path) { product =>
+        Future(Ok(limitExceedPage(weightOrVolume, product.token, product.name)))
+      }
     }
-  }
 }

--- a/app/controllers/enforce/JourneyEnforcer.scala
+++ b/app/controllers/enforce/JourneyEnforcer.scala
@@ -19,15 +19,14 @@ package controllers.enforce
 import config.AppConfig
 import connectors.Cache
 import controllers.{LocalContext, routes}
-import javax.inject.{Inject, Singleton}
 import play.api.Logger
 import play.api.mvc.Results._
 import play.api.mvc._
 import uk.gov.hmrc.http.SessionKeys
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class JourneyEnforcer {
@@ -272,25 +271,21 @@ class DeclareAction @Inject() (appConfig: AppConfig, publicAction: PublicAction,
     }
 
   private def declarationJourney(context: LocalContext): Boolean = context.journeyData.isDefined &&
-    (context.getJourneyData.calculatorResponse.fold(false)(x =>
+    (context.getJourneyData.calculatorResponse.exists(x =>
       BigDecimal(x.calculation.allTax) > 0 && BigDecimal(x.calculation.allTax) <= appConfig.paymentLimit
     ) ||
-      (context.getJourneyData.euCountryCheck.getOrElse(
-        ""
-      ) == "greatBritain" && context.getJourneyData.calculatorResponse.fold(false)(x =>
-        BigDecimal(x.calculation.allTax) == 0 && x.isAnyItemOverAllowance
-      )))
+      (context.getJourneyData.euCountryCheck.contains("greatBritain") && context.getJourneyData.calculatorResponse
+        .exists(x => BigDecimal(x.calculation.allTax) == 0 && x.isAnyItemOverAllowance)))
 
   private def amendmentJourney(context: LocalContext): Boolean =
     context.journeyData.isDefined && context.getJourneyData.calculatorResponse.isDefined &&
       (context.getJourneyData.deltaCalculation.fold(false)(x =>
         BigDecimal(x.allTax) > 0 && BigDecimal(x.allTax) <= appConfig.paymentLimit
       ) ||
-        (context.getJourneyData.euCountryCheck.getOrElse(
-          ""
-        ) == "greatBritain" && context.getJourneyData.deltaCalculation.fold(false)(x =>
-          BigDecimal(x.allTax) == 0 && context.getJourneyData.calculatorResponse.get.isAnyItemOverAllowance
-        )))
+        (context.getJourneyData.euCountryCheck.contains("greatBritain") && context.getJourneyData.deltaCalculation
+          .exists(x =>
+            BigDecimal(x.allTax) == 0 && context.getJourneyData.calculatorResponse.get.isAnyItemOverAllowance
+          )))
 
 }
 

--- a/app/util.scala
+++ b/app/util.scala
@@ -25,7 +25,6 @@ import java.math.RoundingMode
 import java.text.DecimalFormat
 import scala.util.Try
 
-
 package object util {
 
   val decimalFormat10: DecimalFormat = {

--- a/app/views/purchased_products/limit_exceed.scala.html
+++ b/app/views/purchased_products/limit_exceed.scala.html
@@ -20,103 +20,39 @@
 @this(
     govukLayout: templates.GovukLayoutWrapper,
     h1: components.h1,
+    h2: components.h2,
     p: components.p,
     warning: components.warning,
     button: components.button,
-    formHelper: FormWithCSRF,
+    formHelper: FormWithCSRF
 )
-@(itemType: String, headerLabel: String)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
+@(enteredAmount: String, token: String, productName: String)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
 
-@govukLayout(pageTitle = Some(messages(headerLabel)  + " - " + messages("service.name") + " - " + messages("site.govuk"))) {
+@govukLayout(pageTitle = Some(messages("limitExceeded.title")  + " - " + messages("service.name") + " - " + messages("site.govuk"))) {
 
-    @h1(messages(headerLabel))
+    @h1(messages("limitExceeded.h1"))
 
-    @if(itemType.contains("tobacco")) {
+    @p(Html(messages("limitExceeded.p1", enteredAmount, messages(s"limitExceeded.p1.$token"))), id=Some("entered-amount"))
 
-        @p(Html(messages("label.limit_exceed_tobacco")), id=Some("table-heading-tobacco"))
-        <table class="govuk-table">
-            <caption class="govuk-table__caption govuk-visually-hidden">@messages(headerLabel)</caption>
-            <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-                <th class="table-60 govuk-table__header" >@messages("label.type_of_tobacco")</th>
-                <th class="govuk-table__header">@messages("label.amount")</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell">@messages("label.cigarettes")</td>
-                <td class="govuk-table__cell">@messages("label.800")</td>
-            </tr>
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell">@messages("label.cigars")</td>
-                <td class="govuk-table__cell">@messages("label.200")</td>
-            </tr>
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell">@messages("label.cigarillos")</td>
-                <td class="govuk-table__cell">@messages("label.400")</td>
-            </tr>
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell">@messages("label.loose_tobacco")</td>
-                <td class="govuk-table__cell">@messages("label.1_kg")</td>
-            </tr>
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell">@messages("label.tobacco_for_heating")</td>
-                <td class="govuk-table__cell">@messages("label.800_sticks")</td>
-            </tr>
-            </tbody>
-        </table>
+    @p(Html(messages("limitExceeded.p2", messages(s"limitExceeded.p2.$token"))), id=Some("limit-exceeded-cannot-use-service"))
 
-        <div class="govuk-inset-text">
-            @p(Html(messages("label.must_declare_over_limits_tobacco")))
-            @p(Html(messages("label.bringing_for_personal_use_tobacco")))
-            @p(Html(messages("label.border_force_officer_will_calculate")))
-        </div>
+    @p(Html(messages("limitExceeded.p3")), id=Some("item-removed"))
 
-    @warning(Html(messages("text.warning_for_false_declaration_tobacco")))
+    @h2(messages("limitExceeded.h2a"), id = Some("what-you-must-do"))
 
-    } else if(itemType.contains("alcohol")) {
+    @p(Html(messages("limitExceeded.p4")), id=Some("red-channel"))
 
-        @p(Html(messages("label.limit_exceed_alcohol")), id=Some("table-heading-alcohol"))
-        <table class="govuk-table">
-            <caption class="govuk-table__caption govuk-visually-hidden">@messages(headerLabel)</caption>
-            <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-                <th class="table-60 govuk-table__header">@messages("label.type_of_alcohol")</th>
-                <th class="govuk-table__header">@messages("label.amount")</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell">@messages("label.beer")</td>
-                <td class="govuk-table__cell">@messages("label.110_litres")</td>
-            </tr>
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell">@messages("label.wine")</td>
-                <td class="govuk-table__cell">@messages("label.90_litres")<br>@messages("label.including_sparkling_wine")</td>
-            </tr>
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell">@messages("label.spirits")</td>
-                <td class="govuk-table__cell">@messages("label.10_litres")</td>
-            </tr>
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell">@messages("label.other_alcoholic_drinks")</td>
-                <td class="govuk-table__cell">@messages("label.20_litres")</td>
-            </tr>
-            </tbody>
-        </table>
-
-        <div class="govuk-inset-text">
-            @p(Html(messages("label.must_declare_over_limits_alcohol")))
-            @p(Html(messages("label.bringing_for_personal_use_alcohol")))
-            @p(Html(messages("label.border_force_officer_will_calculate")))
-        </div>
-
-    @warning(Html(messages("text.warning_for_false_declaration_alcohol")))
+    @if(productName.contains("alcohol")) {
+        @warning(Html(messages("limitExceeded.warning.alcohol")))
+    } else {
+        @warning(Html(messages("limitExceeded.warning.tobacco")))
     }
 
-    <br>
+    @h2(messages("limitExceeded.h2b"), id = Some("other-items"))
+
+    @p(Html(messages("limitExceeded.p5")), id=Some("declare-other-items"))
 
     @formHelper(action = routes.SelectProductController.nextStep) {
-        @button(messages("label.continue_to_add_items"))
+        @button(messages("label.continue"))
     }
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -81,7 +81,7 @@ GET        /keep-alive                                                          
 GET        /tell-us                                                                    controllers.DashboardController.showDashboard
 POST       /tell-us                                                                    controllers.CalculateDeclareController.calculate
 
-GET        /goods/$path<.+>/upper-limits                                               controllers.LimitExceedController.loadLimitExceedPage(path: ProductPath)
+GET        /goods/$path<.+>/upper-limits/:weightOrVolume                               controllers.LimitExceedController.loadLimitExceedPage(path: ProductPath, weightOrVolume: String)
 
 GET        /remove-goods/$path<.+>/:iid/remove                                         controllers.AlterProductsController.confirmRemove(path: ProductPath, iid: String)
 POST       /remove-goods/$path<.+>/:iid/remove                                         controllers.AlterProductsController.remove(path: ProductPath, iid: String)

--- a/conf/messages
+++ b/conf/messages
@@ -1412,30 +1412,54 @@ label.no_existing_declaration = the details you have entered do not match an exi
 label.payment_issue = there was an issue when you previously tried to add goods to your declaration and your payment was not completed - you will now need to speak to a border force officer at your arrival location to declare any additional goods
 label.already_passed_custom = your scheduled time of arrival is in the past - if your journey has been delayed and you have goods to declare, speak to a border force officer at your arrival location
 
-#limit exceed page
-heading.l-cigrt.limit-exceeded = You cannot use this service to declare more than 800 cigarettes
-heading.l-cigar.limit-exceeded = You cannot use this service to declare more than 200 cigars
-heading.l-crilo.limit-exceeded = You cannot use this service to declare more than 400 cigarillos
-heading.l-loose.limit-exceeded = You cannot use this service to declare more than 1kg of loose tobacco
-heading.l-htb.limit-exceeded = You cannot use this service to declare more than 800 sticks of tobacco for heating
-heading.l-beer.limit-exceeded = You cannot use this service to declare more than 110 litres of beer
-heading.l-wine.limit-exceeded = You cannot use this service to declare more than 90 litres of wine
-heading.l-winesp.limit-exceeded = You cannot use this service to declare more than 60 litres of sparkling wine
-heading.l-spirit.limit-exceeded = You cannot use this service to declare more than 10 litres of spirits
-heading.l-alcoth.limit-exceeded = You cannot use this service to declare more than 20 litres of other alcoholic drinks
-label.limit_exceed_alcohol = You cannot use this service to declare more than the following amounts of alcohol:
-label.limit_exceed_tobacco = You cannot use this service to declare more than the following amounts of tobacco:
-label.including_sparkling_wine = (including a maximum of 60 litres of sparkling wine)
-label.must_declare_over_limits_alcohol = You must declare alcohol over these limits in person to Border Force when you arrive in the UK.
-label.must_declare_over_limits_tobacco = You must declare tobacco over these limits in person to Border Force when you arrive in the UK.
-label.bringing_for_personal_use_alcohol = This is because Border Force need to be sure you are bringing the alcohol in for personal use only.
-label.bringing_for_personal_use_tobacco = This is because Border Force need to be sure you are bringing the tobacco in for personal use only.
-label.border_force_officer_will_calculate = Once a Border Force officer is sure of this, they will calculate and take payment of the taxes and duties due.
-text.warning_for_false_declaration_alcohol = If you do not declare alcohol over these limits in person, or make a false declaration, you may have to pay a penalty and your alcohol may be seized.
-text.warning_for_false_declaration_tobacco = If you do not declare tobacco over these limits in person, or make a false declaration, you may have to pay a penalty and your tobacco may be seized.
-label.continue_to_add_items = Continue to add items
-label.type_of_alcohol = Type of alcohol
-label.type_of_tobacco = Type of tobacco
+# limit exceed page
+
+limitExceeded.title = There is a problem
+limitExceeded.h1 = There is a problem
+limitExceeded.p1 = You have entered {0} {1}
+
+limitExceeded.p1.beer = litres of beer.
+limitExceeded.p1.cider = litres of cider.
+limitExceeded.p1.non-sparkling-cider = litres of cider.
+limitExceeded.p1.sparkling-cider = litres of cider.
+limitExceeded.p1.sparkling-cider-up = litres of cider.
+limitExceeded.p1.sparkling-wine = litres of sparkling wine.
+limitExceeded.p1.spirits = litres of spirits.
+limitExceeded.p1.wine = litres of wine.
+limitExceeded.p1.other = litres of other alcohol.
+
+limitExceeded.p1.cigarettes = cigarettes.
+limitExceeded.p1.cigarillos = cigarillos.
+limitExceeded.p1.cigars = cigars.
+limitExceeded.p1.heated-tobacco = tobacco sticks.
+limitExceeded.p1.chewing-tobacco = grams of tobacco.
+limitExceeded.p1.rolling-tobacco = grams of tobacco.
+
+limitExceeded.p2 = You cannot use this service to declare more than {0}
+limitExceeded.p3 = This item will be removed from your goods to declare.
+limitExceeded.h2a = What you must do
+limitExceeded.p4 = You must use the red channel to declare this item in person to Border Force when you arrive in the UK. They will calculate and take payment of the taxes and duties due.
+limitExceeded.warning.alcohol = If you do not declare alcohol over the service limit in person, or if you make a false declaration, you may have to pay a penalty and your alcohol may be seized.
+limitExceeded.warning.tobacco = If you do not declare tobacco over the service limit in person, or if you make a false declaration, you may have to pay a penalty and your tobacco may be seized.
+limitExceeded.h2b = If you have other items to declare
+limitExceeded.p5 = You can continue to use this service to declare other alcohol, tobacco and goods.
+
+limitExceeded.p2.beer = 110 litres of beer.
+limitExceeded.p2.non-sparkling-cider = 20 litres of cider.
+limitExceeded.p2.sparkling-cider = 20 litres of cider.
+limitExceeded.p2.sparkling-cider-up = 20 litres of cider.
+limitExceeded.p2.sparkling-wine = 60 litres of sparkling wine.
+limitExceeded.p2.spirits = 10 litres of spirits.
+limitExceeded.p2.wine = 90 litres of wine (this includes up to 60 litres of sparkling wine).
+limitExceeded.p2.other = 20 litres of other alcohol.
+
+limitExceeded.p2.cigarettes = 800 cigarettes.
+limitExceeded.p2.cigarillos = 400 cigarillos.
+limitExceeded.p2.cigars = 200 cigars.
+limitExceeded.p2.heated-tobacco = 800 tobacco sticks.
+limitExceeded.p2.chewing-tobacco = 1000 grams of tobacco.
+limitExceeded.p2.rolling-tobacco = 1000 grams of tobacco.
+
 
 #Previous declaration page content change
 label.check_tax_and_declare = Check tax on goods and declare them

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1412,30 +1412,54 @@ label.no_existing_declaration = nid yw’r manylion a nodwyd gennych yn cyd-fynd
 label.payment_issue = roedd problem pan wnaethoch geisio ychwanegu nwyddau at eich datganiad yn flaenorol ac ni chwblhawyd eich taliad - bydd angen i chi nawr siarad â swyddog llu’r ffiniau yn eich man cyrraedd i ddatgan unrhyw nwyddau ychwanegol
 label.already_passed_custom = mae’ch amser cyrraedd disgwyliedig yn y gorffennol - os gohiriwyd eich taith a bod gennych nwyddau i’w datgan, siaradwch â swyddog Llu’r Ffiniau yn eich man cyrraedd
 
-#limit exceed page
-heading.l-cigrt.limit-exceeded = Ni allwch ddefnyddio’r gwasanaeth hwn i ddatgan mwy nag 800 sigarét
-heading.l-cigar.limit-exceeded = Ni allwch ddefnyddio’r gwasanaeth hwn i ddatgan mwy na 200 sigâr
-heading.l-crilo.limit-exceeded = Ni allwch ddefnyddio’r gwasanaeth hwn i ddatgan mwy na 400 sigarilo
-heading.l-loose.limit-exceeded = Ni allwch ddefnyddio’r gwasanaeth hwn i ddatgan mwy na 1kg o dybaco rhydd
-heading.l-htb.limit-exceeded = Ni allwch ddefnyddio’r gwasanaeth hwn i ddatgan mwy nag 800 darn o dybaco gwresogi
-heading.l-beer.limit-exceeded = Ni allwch ddefnyddio’r gwasanaeth hwn i ddatgan mwy na 110 litr o gwrw
-heading.l-wine.limit-exceeded = Ni allwch ddefnyddio’r gwasanaeth hwn i ddatgan mwy na 90 litr o win
-heading.l-winesp.limit-exceeded = Ni allwch ddefnyddio’r gwasanaeth hwn i ddatgan mwy na 60 litr o win pefriog
-heading.l-spirit.limit-exceeded = Ni allwch ddefnyddio’r gwasanaeth hwn i ddatgan mwy na 10 litr o wirodydd
-heading.l-alcoth.limit-exceeded = Ni allwch ddefnyddio’r gwasanaeth hwn i ddatgan mwy nag 20 litr o ddiodydd alcoholaidd eraill
-label.limit_exceed_alcohol = Ni allwch ddefnyddio’r gwasanaeth hwn i ddatgan mwy na’r symiau canlynol o alcohol:
-label.limit_exceed_tobacco = Ni allwch ddefnyddio’r gwasanaeth hwn i ddatgan mwy na’r symiau canlynol o dybaco:
-label.including_sparkling_wine = (gan gynnwys uchafswm o 60 litr o win pefriog)
-label.must_declare_over_limits_alcohol = Mae’n rhaid i chi ddatgan unrhyw alcohol sydd dros y terfynau hyn yn bersonol i Lu’r Ffiniau pan fyddwch yn cyrraedd y DU.
-label.must_declare_over_limits_tobacco = Mae’n rhaid i chi ddatgan unrhyw dybaco sydd dros y terfynau hyn yn bersonol i Lu’r Ffiniau pan fyddwch yn cyrraedd y DU.
-label.bringing_for_personal_use_alcohol = Mae hyn oherwydd bod angen i Lu’r Ffiniau fod yn siŵr eich bod yn dod â’r alcohol i mewn ar gyfer defnydd personol yn unig.
-label.bringing_for_personal_use_tobacco = Mae hyn oherwydd bod angen i Lu’r Ffiniau fod yn siŵr eich bod yn dod â’r tybaco i mewn ar gyfer defnydd personol yn unig.
-label.border_force_officer_will_calculate = Unwaith bo swyddog Llu’r Ffiniau yn siŵr o hyn, bydd yn cyfrifo ac yn cymryd taliad o’r trethi a’r tollau sy’n ddyledus.
-text.warning_for_false_declaration_alcohol = Os nad ydych yn datgan alcohol dros y terfynau hyn yn bersonol, neu os gwnewch ddatganiad ffug, mae’n bosibl y bydd yn rhaid i chi dalu cosb ac mae’n bosibl y bydd eich alcohol yn cael ei atafaelu.
-text.warning_for_false_declaration_tobacco = Os nad ydych yn datgan tybaco dros y terfynau hyn yn bersonol, neu os gwnewch ddatganiad ffug, mae’n bosibl y bydd yn rhaid i chi dalu cosb ac mae’n bosibl y bydd eich tybaco yn cael ei atafaelu.
-label.continue_to_add_items = Yn eich blaen i ychwanegu eitemau
-label.type_of_alcohol = Math o alcohol
-label.type_of_tobacco = Math o dybaco
+# limit exceed page
+
+limitExceeded.title = Mae problem wedi codi
+limitExceeded.h1 = Mae problem wedi codi
+limitExceeded.p1 = Rydych wedi nodi {0} {1}.
+
+limitExceeded.p1.beer = litr o gwrw
+limitExceeded.p1.cider = litr o seidr
+limitExceeded.p1.non-sparkling-cider = litr o seidr
+limitExceeded.p1.sparkling-cider = litr o seidr
+limitExceeded.p1.sparkling-cider-up = litr o seidr
+limitExceeded.p1.sparkling-wine = litr o win pefriog
+limitExceeded.p1.spirits = litr o wirodydd
+limitExceeded.p1.wine = litr o win
+limitExceeded.p1.other = litr o alcohol arall
+
+limitExceeded.p1.cigarettes = sigarét
+limitExceeded.p1.cigarillos = sigarilo
+limitExceeded.p1.cigars = sigâr
+limitExceeded.p1.heated-tobacco = darn o dybaco gwresogi
+limitExceeded.p1.chewing-tobacco = gram o dybaco
+limitExceeded.p1.rolling-tobacco = gram o dybaco
+
+limitExceeded.p2 = Ni allwch ddefnyddio’r gwasanaeth hwn i ddatgan mwy na {0}.
+limitExceeded.p3 = Bydd yr eitem hon yn cael ei dileu o’ch nwyddau i’w datgan.
+limitExceeded.h2a = Yr hyn y mae’n rhaid i chi ei wneud
+limitExceeded.p4 = Mae’n rhaid i chi ddefnyddio’r sianel goch i ddatgan yr eitem hon, yn bersonol, i Lu’r Ffiniau pan fyddwch yn cyrraedd y DU. Byddant yn cyfrifo’r trethi a’r tollau sy’n ddyledus ac yn cymryd taliad ohonynt.
+limitExceeded.warning.alcohol = Os nad ydych yn datgan alcohol dros derfyn y gwasanaeth yn bersonol, neu os gwnewch ddatganiad ffug, mae’n bosibl y bydd yn rhaid i chi dalu cosb ac mae’n bosibl y bydd eich alcohol yn cael ei atafaelu.
+limitExceeded.warning.tobacco = Os nad ydych yn datgan tybaco dros derfyn y gwasanaeth yn bersonol, neu os gwnewch ddatganiad ffug, mae’n bosibl y bydd yn rhaid i chi dalu cosb ac mae’n bosibl y bydd eich tybaco yn cael ei atafaelu.
+limitExceeded.h2b = Os oes gennych eitemau eraill i’w datgan
+limitExceeded.p5 = Gallwch barhau i ddefnyddio’r gwasanaeth hwn er mwyn datgan alcohol, tybaco a nwyddau eraill.
+
+limitExceeded.p2.beer = 110 litr o gwrw
+limitExceeded.p2.cider = 20 litr o seidr
+limitExceeded.p2.non-sparkling-cider = 20 litr o seidr
+limitExceeded.p2.sparkling-cider = 20 litr o seidr
+limitExceeded.p2.sparkling-cider-up = 20 litr o seidr
+limitExceeded.p2.sparkling-wine = 60 litr o win pefriog
+limitExceeded.p2.spirits = 10 litr o wirodydd
+limitExceeded.p2.wine = 90 litr o win (mae hyn yn cynnwys hyd at 60 litr o win pefriog)
+limitExceeded.p2.other = 20 litr o alcohol arall
+
+limitExceeded.p2.cigarettes = 800 sigarét
+limitExceeded.p2.cigarillos = 400 sigarilo
+limitExceeded.p2.cigars = 200 sigâr
+limitExceeded.p2.heated-tobacco = 800 darn o dybaco gwresogi
+limitExceeded.p2.chewing-tobacco = 1000 gram o dybaco
+limitExceeded.p2.rolling-tobacco = 1000 gram o dybaco
 
 #Previous declaration page content change
 label.check_tax_and_declare = Gwirio’r dreth ar nwyddau a’u datgan

--- a/test/controllers/AlcoholInputControllerSpec.scala
+++ b/test/controllers/AlcoholInputControllerSpec.scala
@@ -793,7 +793,7 @@ class AlcoholInputControllerSpec extends BaseSpec with Injecting {
       val result: Future[Result] = route(app, req).get
       status(result)           shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(
-        "/check-tax-on-goods-you-bring-into-the-uk/goods/alcohol/beer/upper-limits"
+        "/check-tax-on-goods-you-bring-into-the-uk/goods/alcohol/beer/upper-limits/111"
       )
     }
 
@@ -814,7 +814,7 @@ class AlcoholInputControllerSpec extends BaseSpec with Injecting {
       val result: Future[Result] = route(app, req).get
       status(result)           shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(
-        "/check-tax-on-goods-you-bring-into-the-uk/goods/alcohol/sparkling-wine/upper-limits"
+        "/check-tax-on-goods-you-bring-into-the-uk/goods/alcohol/sparkling-wine/upper-limits/65"
       )
     }
 
@@ -834,7 +834,7 @@ class AlcoholInputControllerSpec extends BaseSpec with Injecting {
       val result: Future[Result] = route(app, req).get
       status(result)           shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(
-        "/check-tax-on-goods-you-bring-into-the-uk/goods/alcohol/wine/upper-limits"
+        "/check-tax-on-goods-you-bring-into-the-uk/goods/alcohol/wine/upper-limits/95"
       )
     }
 
@@ -992,7 +992,7 @@ class AlcoholInputControllerSpec extends BaseSpec with Injecting {
       val result: Future[Result] = route(app, req).get
       status(result)           shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(
-        "/check-tax-on-goods-you-bring-into-the-uk/goods/alcohol/beer/upper-limits"
+        "/check-tax-on-goods-you-bring-into-the-uk/goods/alcohol/beer/upper-limits/111"
       )
     }
 

--- a/test/controllers/LimitExceedControllerSpec.scala
+++ b/test/controllers/LimitExceedControllerSpec.scala
@@ -52,20 +52,21 @@ class LimitExceedControllerSpec extends BaseSpec {
     reset(mockAppConfig)
   }
 
-  lazy val oldAlcohol: PurchasedProductInstance                         = PurchasedProductInstance(
-    ProductPath("alcohol/beer"),
-    "iid0",
-    Some(1.54332),
-    None,
-    Some(Country("EG", "title.egypt", "EG", isEu = false, isCountry = true, Nil)),
-    None,
-    Some("AUD"),
-    Some(BigDecimal(10.234)),
-    None,
-    None,
-    None,
-    isEditable = Some(false)
-  )
+  lazy val oldAlcohol: PurchasedProductInstance                         =
+    PurchasedProductInstance(
+      path = ProductPath("alcohol/beer"),
+      iid = "iid0",
+      weightOrVolume = Some(1.54332),
+      noOfSticks = None,
+      country = Some(Country("EG", "title.egypt", "EG", isEu = false, isCountry = true, Nil)),
+      originCountry = None,
+      currency = Some("AUD"),
+      cost = Some(BigDecimal(10.234)),
+      searchTerm = None,
+      isVatPaid = None,
+      isCustomPaid = None,
+      isEditable = Some(false)
+    )
   lazy val oldPurchasedProductInstances: List[PurchasedProductInstance] = List(oldAlcohol)
 
   "loadLimitExceedPage" should {
@@ -91,7 +92,7 @@ class LimitExceedControllerSpec extends BaseSpec {
         app,
         enhancedFakeRequest(
           "GET",
-          "/check-tax-on-goods-you-bring-into-the-uk/goods/alcohol/cider/non-sparkling-cider/upper-limits"
+          "/check-tax-on-goods-you-bring-into-the-uk/goods/alcohol/cider/non-sparkling-cider/upper-limits/111.5"
         )
       ).get
       status(result) shouldBe OK
@@ -101,19 +102,13 @@ class LimitExceedControllerSpec extends BaseSpec {
 
       doc
         .getElementsByTag("h1")
-        .text() shouldBe "You cannot use this service to declare more than 20 litres of other alcoholic drinks"
+        .text() shouldBe "There is a problem"
       doc
-        .getElementById("table-heading-alcohol")
-        .text() shouldBe "You cannot use this service to declare more than the following amounts of alcohol:"
+        .getElementById("entered-amount")
+        .text() shouldBe "You have entered 111.5 litres of cider."
       content     should include(
-        "You must declare alcohol over these limits in person to Border Force when you arrive in the UK."
-      )
-      content     should include("Type of alcohol")
-      content     should include(
-        "This is because Border Force need to be sure you are bringing the alcohol in for personal use only."
-      )
-      content     should include(
-        "Once a Border Force officer is sure of this, they will calculate and take payment of the taxes and duties due."
+        "You must use the red channel to declare this item in person to Border Force when you arrive in the UK. " +
+          "They will calculate and take payment of the taxes and duties due."
       )
     }
 
@@ -136,26 +131,20 @@ class LimitExceedControllerSpec extends BaseSpec {
       )
       val result: Future[Result] = route(
         app,
-        enhancedFakeRequest("GET", "/check-tax-on-goods-you-bring-into-the-uk/goods/tobacco/cigars/upper-limits")
+        enhancedFakeRequest("GET", "/check-tax-on-goods-you-bring-into-the-uk/goods/tobacco/cigars/upper-limits/201")
       ).get
       status(result) shouldBe OK
 
       val content = contentAsString(result)
       val doc     = Jsoup.parse(content)
 
-      doc.getElementsByTag("h1").text() shouldBe "You cannot use this service to declare more than 200 cigars"
+      doc.getElementsByTag("h1").text() shouldBe "There is a problem"
       doc
-        .getElementById("table-heading-tobacco")
-        .text()                         shouldBe "You cannot use this service to declare more than the following amounts of tobacco:"
+        .getElementById("entered-amount")
+        .text()                         shouldBe "You have entered 201 cigars."
       content                             should include(
-        "You must declare tobacco over these limits in person to Border Force when you arrive in the UK."
-      )
-      content                             should include("Type of tobacco")
-      content                             should include(
-        "This is because Border Force need to be sure you are bringing the tobacco in for personal use only."
-      )
-      content                             should include(
-        "Once a Border Force officer is sure of this, they will calculate and take payment of the taxes and duties due."
+        "You must use the red channel to declare this item in person to Border Force when you arrive in the UK. " +
+          "They will calculate and take payment of the taxes and duties due."
       )
     }
 

--- a/test/controllers/TobaccoInputControllerSpec.scala
+++ b/test/controllers/TobaccoInputControllerSpec.scala
@@ -1262,7 +1262,7 @@ class TobaccoInputControllerSpec extends BaseSpec {
       val result: Future[Result] = route(app, req).get
       status(result)           shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(
-        "/check-tax-on-goods-you-bring-into-the-uk/goods/tobacco/cigarettes/upper-limits"
+        "/check-tax-on-goods-you-bring-into-the-uk/goods/tobacco/cigarettes/upper-limits/900"
       )
     }
 
@@ -1287,7 +1287,7 @@ class TobaccoInputControllerSpec extends BaseSpec {
       val result: Future[Result] = route(app, req).get
       status(result)           shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(
-        "/check-tax-on-goods-you-bring-into-the-uk/goods/tobacco/heated-tobacco/upper-limits"
+        "/check-tax-on-goods-you-bring-into-the-uk/goods/tobacco/heated-tobacco/upper-limits/801"
       )
     }
 
@@ -1312,7 +1312,7 @@ class TobaccoInputControllerSpec extends BaseSpec {
       val result: Future[Result] = route(app, req).get
       status(result)           shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(
-        "/check-tax-on-goods-you-bring-into-the-uk/goods/tobacco/cigars/upper-limits"
+        "/check-tax-on-goods-you-bring-into-the-uk/goods/tobacco/cigars/upper-limits/400"
       )
     }
 
@@ -1330,14 +1330,14 @@ class TobaccoInputControllerSpec extends BaseSpec {
       ).withFormUrlEncodedBody(
         "country"        -> "FR",
         "currency"       -> "EUR",
-        "weightOrVolume" -> "1001.0",
+        "weightOrVolume" -> "1000.01",
         "cost"           -> "92.50"
       )
 
       val result: Future[Result] = route(app, req).get
       status(result)           shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(
-        "/check-tax-on-goods-you-bring-into-the-uk/goods/tobacco/chewing-tobacco/upper-limits"
+        "/check-tax-on-goods-you-bring-into-the-uk/goods/tobacco/chewing-tobacco/upper-limits/1000.01"
       )
     }
 
@@ -2015,8 +2015,8 @@ class TobaccoInputControllerSpec extends BaseSpec {
           .withFormUrlEncodedBody(
             "country"        -> "FR",
             "currency"       -> "EUR",
-            "weightOrVolume" -> "400.0",
-            "noOfSticks"     -> "50",
+            "weightOrVolume" -> "50",
+            "noOfSticks"     -> "801",
             "cost"           -> "98.00"
           )
 
@@ -2024,7 +2024,7 @@ class TobaccoInputControllerSpec extends BaseSpec {
 
       status(result)           shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(
-        "/check-tax-on-goods-you-bring-into-the-uk/goods/tobacco/cigarettes/upper-limits"
+        "/check-tax-on-goods-you-bring-into-the-uk/goods/tobacco/cigarettes/upper-limits/801"
       )
     }
 
@@ -2041,7 +2041,7 @@ class TobaccoInputControllerSpec extends BaseSpec {
           .withFormUrlEncodedBody(
             "country"        -> "FR",
             "currency"       -> "EUR",
-            "weightOrVolume" -> "201.0",
+            "weightOrVolume" -> "999.5",
             "noOfSticks"     -> "201",
             "cost"           -> "98.00"
           )
@@ -2050,7 +2050,7 @@ class TobaccoInputControllerSpec extends BaseSpec {
 
       status(result)           shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(
-        "/check-tax-on-goods-you-bring-into-the-uk/goods/tobacco/cigars/upper-limits"
+        "/check-tax-on-goods-you-bring-into-the-uk/goods/tobacco/cigars/upper-limits/201"
       )
     }
 
@@ -2067,7 +2067,8 @@ class TobaccoInputControllerSpec extends BaseSpec {
           .withFormUrlEncodedBody(
             "country"        -> "FR",
             "currency"       -> "EUR",
-            "weightOrVolume" -> "1001.0",
+            "weightOrVolume" -> "1000.01",
+            "noOfSticks"     -> "50",
             "cost"           -> "98.00"
           )
 
@@ -2075,7 +2076,7 @@ class TobaccoInputControllerSpec extends BaseSpec {
 
       status(result)           shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(
-        "/check-tax-on-goods-you-bring-into-the-uk/goods/tobacco/chewing-tobacco/upper-limits"
+        "/check-tax-on-goods-you-bring-into-the-uk/goods/tobacco/chewing-tobacco/upper-limits/1000.01"
       )
     }
   }

--- a/test/controllers/ZeroDeclarationControllerSpec.scala
+++ b/test/controllers/ZeroDeclarationControllerSpec.scala
@@ -19,7 +19,6 @@ package controllers
 import config.AppConfig
 import connectors.Cache
 import models._
-import java.time.LocalDate
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.{reset, when}

--- a/test/services/CalculatorServiceSpec.scala
+++ b/test/services/CalculatorServiceSpec.scala
@@ -30,7 +30,8 @@ import play.api.test.Helpers._
 import repositories.BCPassengersSessionRepository
 import services.http.WsAllMethods
 import uk.gov.hmrc.http.UpstreamErrorResponse
-import util.{BaseSpec, formatLocalDate, formatLocalTime, parseLocalDate, parseLocalTime}
+import util.{BaseSpec, parseLocalDate}
+
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import scala.concurrent.Future

--- a/test/services/DeclarationServiceSpec.scala
+++ b/test/services/DeclarationServiceSpec.scala
@@ -18,8 +18,6 @@ package services
 
 import connectors.Cache
 import models._
-
-import java.time.{LocalDate, LocalDateTime}
 import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.mockito.MockitoSugar
@@ -36,6 +34,7 @@ import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import util.{BaseSpec, EnhancedJsObject, parseLocalDate, parseLocalTime}
 
+import java.time.LocalDateTime
 import scala.concurrent.Future
 
 class DeclarationServiceSpec extends BaseSpec with ScalaFutures {

--- a/test/services/PayApiServiceSpec.scala
+++ b/test/services/PayApiServiceSpec.scala
@@ -18,9 +18,6 @@ package services
 
 import connectors.Cache
 import models._
-
-import java.time.format.DateTimeFormatter
-import java.time.{LocalDate, LocalDateTime, LocalTime}
 import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.mockito.MockitoSugar
@@ -36,7 +33,7 @@ import services.http.WsAllMethods
 import uk.gov.hmrc.http.HttpResponse
 import util.{BaseSpec, parseLocalDate, parseLocalTime}
 
-import java.util.Locale
+import java.time.LocalDateTime
 import scala.concurrent.Future
 
 class PayApiServiceSpec extends BaseSpec {

--- a/test/services/UserInformationServiceSpec.scala
+++ b/test/services/UserInformationServiceSpec.scala
@@ -18,7 +18,6 @@ package services
 
 import connectors.Cache
 import models.{JourneyData, UserInformation}
-import java.time.LocalDate
 import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.mockito.MockitoSugar

--- a/test/views/BaseSelectors.scala
+++ b/test/views/BaseSelectors.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,15 +12,15 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@this()
+package views
 
-@(msg: String, id:Option[String] = None)(implicit messages: Messages)
+trait BaseSelectors {
 
-@if(id.isDefined){
-<h2 class="govuk-heading-m" id="@id">@messages(msg)</h2>
-} else {
-<h2 class="govuk-heading-m">@messages(msg)</h2>
+  val p: Int => String      = i => s"main p:nth-of-type($i)"
+  val h2: Int => String     = i => s"main h2:nth-of-type($i)"
+  val bullet: Int => String = i => s"main ul.govuk-list.govuk-list--bullet li:nth-of-type($i)"
+  val warning               = "main .govuk-warning-text__text"
+
 }
-

--- a/test/views/BaseViewSpec.scala
+++ b/test/views/BaseViewSpec.scala
@@ -17,6 +17,7 @@
 package views
 
 import config.AppConfig
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.i18n.{Messages, MessagesApi}
 import play.api.mvc.{AnyContentAsEmpty, Request}
 import play.api.test.FakeRequest
@@ -79,4 +80,16 @@ trait BaseViewSpec extends BaseSpec with ViewSpec {
       }
     }
   }
+
+  def pageWithExpectedMessages(view: HtmlFormat.Appendable, checks: Seq[(String, String)]): Unit =
+    checks.foreach { case (cssSelector, message) =>
+      s"element with cssSelector '$cssSelector'" should {
+
+        s"have message '$message'" in {
+          val doc  = document(view)
+          val elem = doc.select(cssSelector)
+          elem.first.text() mustBe message
+        }
+      }
+    }
 }

--- a/test/views/purchased_products/LimitExceedViewSpec.scala
+++ b/test/views/purchased_products/LimitExceedViewSpec.scala
@@ -17,38 +17,356 @@
 package views.purchased_products
 
 import play.twirl.api.HtmlFormat
-import views.BaseViewSpec
 import views.html.purchased_products.limit_exceed
+import views.{BaseSelectors, BaseViewSpec}
 
 class LimitExceedViewSpec extends BaseViewSpec {
 
-  val viewViaApply: HtmlFormat.Appendable = injected[limit_exceed].apply(
-    itemType = "label.tobacco.cigars",
-    headerLabel = "heading.l-cigar.limit-exceeded"
-  )(
-    request = request,
-    messages = messages,
-    appConfig = appConfig
-  )
+  val viewViaApply: HtmlFormat.Appendable =
+    injected[limit_exceed].apply(
+      "110",
+      "cigars",
+      "label.tobacco.cigars"
+    )(
+      request = request,
+      messages = messages,
+      appConfig = appConfig
+    )
 
-  val viewViaRender: HtmlFormat.Appendable = injected[limit_exceed].render(
-    itemType = "label.tobacco.cigars",
-    headerLabel = "heading.l-cigar.limit-exceeded",
-    request = request,
-    messages = messages,
-    appConfig = appConfig
-  )
+  val viewViaRender: HtmlFormat.Appendable =
+    injected[limit_exceed].render(
+      "110.2",
+      "cigars",
+      "label.tobacco.cigars",
+      request = request,
+      messages = messages,
+      appConfig = appConfig
+    )
 
-  val viewViaF: HtmlFormat.Appendable = injected[limit_exceed].f(
-    "label.tobacco.cigars",
-    "heading.l-cigar.limit-exceeded"
-  )(request, messages, appConfig)
+  val viewViaF: HtmlFormat.Appendable =
+    injected[limit_exceed].f("110.2", "cigars", "label.tobacco.cigars")(request, messages, appConfig)
+
+  object Selectors extends BaseSelectors
+
+  def viewApply(amount: String, item: String, productName: String): HtmlFormat.Appendable =
+    injected[limit_exceed]
+      .apply(amount, item, productName)(request = request, messages = messages, appConfig = appConfig)
 
   "LimitExceedView" when {
+
     renderViewTest(
-      title =
-        "You cannot use this service to declare more than 200 cigars - Check tax on goods you bring into the UK - GOV.UK",
-      heading = "You cannot use this service to declare more than 200 cigars"
+      title = "There is a problem - Check tax on goods you bring into the UK - GOV.UK",
+      heading = "There is a problem"
     )
+
+    "Alcohol" should {
+
+      "display correct content for view" when {
+
+        "the user enters too much beer" should {
+
+          val view = viewApply("110.5", "beer", "label.alcohol.beer")
+
+          val expectedContent =
+            Seq(
+              Selectors.p(1)    -> "You have entered 110.5 litres of beer.",
+              Selectors.p(2)    -> "You cannot use this service to declare more than 110 litres of beer.",
+              Selectors.p(3)    -> "This item will be removed from your goods to declare.",
+              Selectors.h2(1)   -> "What you must do",
+              Selectors.p(4)    ->
+                (
+                  "You must use the red channel to declare this item in person to Border Force when you arrive in the UK. " +
+                    "They will calculate and take payment of the taxes and duties due."
+                ),
+              Selectors.warning -> "Warning If you do not declare alcohol over the service limit in person, or if you make a false declaration, you may have to pay a penalty and your alcohol may be seized.",
+              Selectors.h2(2)   -> "If you have other items to declare",
+              Selectors.p(5)    -> "You can continue to use this service to declare other alcohol, tobacco and goods."
+            )
+
+          behave like pageWithExpectedMessages(view, expectedContent)
+        }
+
+        "the user enters too much non-sparkling cider" should {
+
+          val view = viewApply("20.01", "non-sparkling-cider", "label.alcohol.non-sparkling-cider")
+
+          val expectedContent =
+            Seq(
+              Selectors.p(1)    -> "You have entered 20.01 litres of cider.",
+              Selectors.p(2)    -> "You cannot use this service to declare more than 20 litres of cider.",
+              Selectors.p(3)    -> "This item will be removed from your goods to declare.",
+              Selectors.h2(1)   -> "What you must do",
+              Selectors.p(4)    ->
+                (
+                  "You must use the red channel to declare this item in person to Border Force when you arrive in the UK. " +
+                    "They will calculate and take payment of the taxes and duties due."
+                ),
+              Selectors.warning -> "Warning If you do not declare alcohol over the service limit in person, or if you make a false declaration, you may have to pay a penalty and your alcohol may be seized.",
+              Selectors.h2(2)   -> "If you have other items to declare",
+              Selectors.p(5)    -> "You can continue to use this service to declare other alcohol, tobacco and goods."
+            )
+
+          behave like pageWithExpectedMessages(view, expectedContent)
+        }
+
+        "the user enters too much sparkling-cider" should {
+
+          val view = viewApply("20.01", "sparkling-cider", "label.alcohol.sparkling-cider")
+
+          val expectedContent =
+            Seq(
+              Selectors.p(1)    -> "You have entered 20.01 litres of cider.",
+              Selectors.p(2)    -> "You cannot use this service to declare more than 20 litres of cider.",
+              Selectors.p(3)    -> "This item will be removed from your goods to declare.",
+              Selectors.h2(1)   -> "What you must do",
+              Selectors.p(4)    ->
+                (
+                  "You must use the red channel to declare this item in person to Border Force when you arrive in the UK. " +
+                    "They will calculate and take payment of the taxes and duties due."
+                ),
+              Selectors.warning -> "Warning If you do not declare alcohol over the service limit in person, or if you make a false declaration, you may have to pay a penalty and your alcohol may be seized.",
+              Selectors.h2(2)   -> "If you have other items to declare",
+              Selectors.p(5)    -> "You can continue to use this service to declare other alcohol, tobacco and goods."
+            )
+
+          behave like pageWithExpectedMessages(view, expectedContent)
+        }
+
+        "the user enters too much sparkling-cider-up" should {
+
+          val view = viewApply("20.01", "sparkling-cider-up", "label.alcohol.sparkling-cider-up")
+
+          val expectedContent =
+            Seq(
+              Selectors.p(1)    -> "You have entered 20.01 litres of cider.",
+              Selectors.p(2)    -> "You cannot use this service to declare more than 20 litres of cider.",
+              Selectors.p(3)    -> "This item will be removed from your goods to declare.",
+              Selectors.h2(1)   -> "What you must do",
+              Selectors.p(4)    ->
+                (
+                  "You must use the red channel to declare this item in person to Border Force when you arrive in the UK. " +
+                    "They will calculate and take payment of the taxes and duties due."
+                ),
+              Selectors.warning -> "Warning If you do not declare alcohol over the service limit in person, or if you make a false declaration, you may have to pay a penalty and your alcohol may be seized.",
+              Selectors.h2(2)   -> "If you have other items to declare",
+              Selectors.p(5)    -> "You can continue to use this service to declare other alcohol, tobacco and goods."
+            )
+
+          behave like pageWithExpectedMessages(view, expectedContent)
+        }
+
+        "the user enters too much spirits" should {
+
+          val view = viewApply("10.01", "spirits", "label.alcohol.spirits")
+
+          val expectedContent =
+            Seq(
+              Selectors.p(1)    -> "You have entered 10.01 litres of spirits.",
+              Selectors.p(2)    -> "You cannot use this service to declare more than 10 litres of spirits.",
+              Selectors.p(3)    -> "This item will be removed from your goods to declare.",
+              Selectors.h2(1)   -> "What you must do",
+              Selectors.p(4)    ->
+                (
+                  "You must use the red channel to declare this item in person to Border Force when you arrive in the UK. " +
+                    "They will calculate and take payment of the taxes and duties due."
+                ),
+              Selectors.warning -> "Warning If you do not declare alcohol over the service limit in person, or if you make a false declaration, you may have to pay a penalty and your alcohol may be seized.",
+              Selectors.h2(2)   -> "If you have other items to declare",
+              Selectors.p(5)    -> "You can continue to use this service to declare other alcohol, tobacco and goods."
+            )
+
+          behave like pageWithExpectedMessages(view, expectedContent)
+        }
+
+        "the user enters too much wine" should {
+
+          val view = viewApply("90.01", "wine", "label.alcohol.wine")
+
+          val expectedContent =
+            Seq(
+              Selectors.p(1)    -> "You have entered 90.01 litres of wine.",
+              Selectors.p(
+                2
+              )                 -> "You cannot use this service to declare more than 90 litres of wine (this includes up to 60 litres of sparkling wine).",
+              Selectors.p(3)    -> "This item will be removed from your goods to declare.",
+              Selectors.h2(1)   -> "What you must do",
+              Selectors.p(4)    ->
+                (
+                  "You must use the red channel to declare this item in person to Border Force when you arrive in the UK. " +
+                    "They will calculate and take payment of the taxes and duties due."
+                ),
+              Selectors.warning -> "Warning If you do not declare alcohol over the service limit in person, or if you make a false declaration, you may have to pay a penalty and your alcohol may be seized.",
+              Selectors.h2(2)   -> "If you have other items to declare",
+              Selectors.p(5)    -> "You can continue to use this service to declare other alcohol, tobacco and goods."
+            )
+
+          behave like pageWithExpectedMessages(view, expectedContent)
+        }
+
+        "the user enters too much other alcohol" should {
+
+          val view = viewApply("20.01", "other", "label.alcohol.other")
+
+          val expectedContent =
+            Seq(
+              Selectors.p(1)    -> "You have entered 20.01 litres of other alcohol.",
+              Selectors.p(2)    -> "You cannot use this service to declare more than 20 litres of other alcohol.",
+              Selectors.p(3)    -> "This item will be removed from your goods to declare.",
+              Selectors.h2(1)   -> "What you must do",
+              Selectors.p(4)    ->
+                (
+                  "You must use the red channel to declare this item in person to Border Force when you arrive in the UK. " +
+                    "They will calculate and take payment of the taxes and duties due."
+                ),
+              Selectors.warning -> "Warning If you do not declare alcohol over the service limit in person, or if you make a false declaration, you may have to pay a penalty and your alcohol may be seized.",
+              Selectors.h2(2)   -> "If you have other items to declare",
+              Selectors.p(5)    -> "You can continue to use this service to declare other alcohol, tobacco and goods."
+            )
+
+          behave like pageWithExpectedMessages(view, expectedContent)
+        }
+      }
+    }
+
+    "Tobacco" should {
+
+      "the user enters too many cigarettes" should {
+
+        val view = viewApply("801", "cigarettes", "label.tobacco.cigarettes")
+
+        val expectedContent =
+          Seq(
+            Selectors.p(1)    -> "You have entered 801 cigarettes.",
+            Selectors.p(2)    -> "You cannot use this service to declare more than 800 cigarettes.",
+            Selectors.p(3)    -> "This item will be removed from your goods to declare.",
+            Selectors.h2(1)   -> "What you must do",
+            Selectors.p(4)    ->
+              (
+                "You must use the red channel to declare this item in person to Border Force when you arrive in the UK. " +
+                  "They will calculate and take payment of the taxes and duties due."
+              ),
+            Selectors.warning -> "Warning If you do not declare tobacco over the service limit in person, or if you make a false declaration, you may have to pay a penalty and your tobacco may be seized.",
+            Selectors.h2(2)   -> "If you have other items to declare",
+            Selectors.p(5)    -> "You can continue to use this service to declare other alcohol, tobacco and goods."
+          )
+
+        behave like pageWithExpectedMessages(view, expectedContent)
+      }
+
+      "the user enters too many cigarillos" should {
+
+        val view = viewApply("401", "cigarillos", "label.tobacco.cigarillos")
+
+        val expectedContent =
+          Seq(
+            Selectors.p(1)    -> "You have entered 401 cigarillos.",
+            Selectors.p(2)    -> "You cannot use this service to declare more than 400 cigarillos.",
+            Selectors.p(3)    -> "This item will be removed from your goods to declare.",
+            Selectors.h2(1)   -> "What you must do",
+            Selectors.p(4)    ->
+              (
+                "You must use the red channel to declare this item in person to Border Force when you arrive in the UK. " +
+                  "They will calculate and take payment of the taxes and duties due."
+              ),
+            Selectors.warning -> "Warning If you do not declare tobacco over the service limit in person, or if you make a false declaration, you may have to pay a penalty and your tobacco may be seized.",
+            Selectors.h2(2)   -> "If you have other items to declare",
+            Selectors.p(5)    -> "You can continue to use this service to declare other alcohol, tobacco and goods."
+          )
+
+        behave like pageWithExpectedMessages(view, expectedContent)
+      }
+
+      "the user enters too many cigars" should {
+
+        val view = viewApply("201", "cigars", "label.tobacco.cigars")
+
+        val expectedContent =
+          Seq(
+            Selectors.p(1)    -> "You have entered 201 cigars.",
+            Selectors.p(2)    -> "You cannot use this service to declare more than 200 cigars.",
+            Selectors.p(3)    -> "This item will be removed from your goods to declare.",
+            Selectors.h2(1)   -> "What you must do",
+            Selectors.p(4)    ->
+              (
+                "You must use the red channel to declare this item in person to Border Force when you arrive in the UK. " +
+                  "They will calculate and take payment of the taxes and duties due."
+              ),
+            Selectors.warning -> "Warning If you do not declare tobacco over the service limit in person, or if you make a false declaration, you may have to pay a penalty and your tobacco may be seized.",
+            Selectors.h2(2)   -> "If you have other items to declare",
+            Selectors.p(5)    -> "You can continue to use this service to declare other alcohol, tobacco and goods."
+          )
+
+        behave like pageWithExpectedMessages(view, expectedContent)
+      }
+
+      "the user enters much heated-tobacco" should {
+
+        val view = viewApply("801", "heated-tobacco", "label.tobacco.heated-tobacco")
+
+        val expectedContent =
+          Seq(
+            Selectors.p(1)    -> "You have entered 801 tobacco sticks.",
+            Selectors.p(2)    -> "You cannot use this service to declare more than 800 tobacco sticks.",
+            Selectors.p(3)    -> "This item will be removed from your goods to declare.",
+            Selectors.h2(1)   -> "What you must do",
+            Selectors.p(4)    ->
+              (
+                "You must use the red channel to declare this item in person to Border Force when you arrive in the UK. " +
+                  "They will calculate and take payment of the taxes and duties due."
+              ),
+            Selectors.warning -> "Warning If you do not declare tobacco over the service limit in person, or if you make a false declaration, you may have to pay a penalty and your tobacco may be seized.",
+            Selectors.h2(2)   -> "If you have other items to declare",
+            Selectors.p(5)    -> "You can continue to use this service to declare other alcohol, tobacco and goods."
+          )
+
+        behave like pageWithExpectedMessages(view, expectedContent)
+      }
+
+      "the user enters much chewing-tobacco" should {
+
+        val view = viewApply("1001", "chewing-tobacco", "label.tobacco.chewing-tobacco")
+
+        val expectedContent =
+          Seq(
+            Selectors.p(1)    -> "You have entered 1001 grams of tobacco.",
+            Selectors.p(2)    -> "You cannot use this service to declare more than 1000 grams of tobacco.",
+            Selectors.p(3)    -> "This item will be removed from your goods to declare.",
+            Selectors.h2(1)   -> "What you must do",
+            Selectors.p(4)    ->
+              (
+                "You must use the red channel to declare this item in person to Border Force when you arrive in the UK. " +
+                  "They will calculate and take payment of the taxes and duties due."
+              ),
+            Selectors.warning -> "Warning If you do not declare tobacco over the service limit in person, or if you make a false declaration, you may have to pay a penalty and your tobacco may be seized.",
+            Selectors.h2(2)   -> "If you have other items to declare",
+            Selectors.p(5)    -> "You can continue to use this service to declare other alcohol, tobacco and goods."
+          )
+
+        behave like pageWithExpectedMessages(view, expectedContent)
+      }
+
+      "the user enters much rolling-tobacco" should {
+
+        val view = viewApply("1001", "rolling-tobacco", "label.tobacco.rolling-tobacco")
+
+        val expectedContent =
+          Seq(
+            Selectors.p(1)    -> "You have entered 1001 grams of tobacco.",
+            Selectors.p(2)    -> "You cannot use this service to declare more than 1000 grams of tobacco.",
+            Selectors.p(3)    -> "This item will be removed from your goods to declare.",
+            Selectors.h2(1)   -> "What you must do",
+            Selectors.p(4)    ->
+              (
+                "You must use the red channel to declare this item in person to Border Force when you arrive in the UK. " +
+                  "They will calculate and take payment of the taxes and duties due."
+              ),
+            Selectors.warning -> "Warning If you do not declare tobacco over the service limit in person, or if you make a false declaration, you may have to pay a penalty and your tobacco may be seized.",
+            Selectors.h2(2)   -> "If you have other items to declare",
+            Selectors.p(5)    -> "You can continue to use this service to declare other alcohol, tobacco and goods."
+          )
+
+        behave like pageWithExpectedMessages(view, expectedContent)
+      }
+    }
   }
 }


### PR DESCRIPTION
Ignoring dep bumps for now to keep the change smaller. Will likely pull in latest dep bumps from https://jira.tools.tax.service.gov.uk/browse/DDCE-5085 so should probably wait for that first. 

~~Idea for now is to use a path parameter. As it's a kick out page the user could change it to change the volume/weight/amount content of the page. However it literally does nothing to the data except change content so see little risk in doing so.~~

~~General searching online suggests the when passing content it should be stored but in this case we care very little about the data the user is trying to enter. Just to display what they entered on the previous page.~~

~~Tried adding the data to the cache so we can retrieve the data on the kickout over limit page. But it would add the data to the cache and the user can backtrack through via browser and it will appear on the "Add items" Dashboard. If recalling correctly there is no method for deleting from cache, there is update which could work but it would still be messy just to display small content.~~

~~Any other ideas?~~

See https://github.com/hmrc/bc-passengers-frontend/pull/447 for adding it to session.