### PR TITLE
DDCE-4964b add previouly declared items to the calculation, raise cov…

### DIFF
--- a/app/models/ProductTreeNode.scala
+++ b/app/models/ProductTreeNode.scala
@@ -18,7 +18,8 @@ package models
 
 import utils.FormatsAndConversions
 
-import scala.math.BigDecimal.RoundingMode
+import util.decimalFormat10
+import utils.FormatsAndConversions
 
 sealed trait ProductTreeNode {
   def name: String
@@ -43,7 +44,7 @@ case class ProductTreeLeaf(
     long: Boolean
   ): Option[(String, List[String])] =
     templateId match {
-      case "cigars" if long =>
+      case "cigars" if long        =>
         for {
           noOfSticks     <- purchasedProductInstance.noOfSticks
           weightOrVolume <- purchasedProductInstance.weightOrVolume
@@ -54,16 +55,12 @@ case class ProductTreeLeaf(
               List(
                 noOfSticks.toString,
                 name + ".single",
-                (weightOrVolume * 1000).formatDecimalPlaces(2).toString
+                decimalFormat10.format(weightOrVolume * 1000)
               )
             )
           } else {
-            (
-              "label.X_X_Xg",
-              List(noOfSticks.toString, name, (weightOrVolume * 1000).formatDecimalPlaces(2).toString)
-            )
+            ("label.X_X_Xg", List(noOfSticks.toString, name, decimalFormat10.format(weightOrVolume * 1000)))
           }
-
       case "cigarettes" | "cigars" =>
         for (noOfSticks <- purchasedProductInstance.noOfSticks)
           yield
@@ -74,9 +71,8 @@ case class ProductTreeLeaf(
             }
       case "tobacco"               =>
         for (weightOrVolume <- purchasedProductInstance.weightOrVolume)
-          yield ("label.Xg_of_X", List((weightOrVolume * 1000).formatDecimalPlaces(2).toString, name))
-
-      case "alcohol"     =>
+          yield ("label.Xg_of_X", List(decimalFormat10.format(weightOrVolume * 1000), name))
+      case "alcohol"               =>
         for (weightOrVolume <- purchasedProductInstance.weightOrVolume)
           yield
             if (weightOrVolume == BigDecimal(1)) {
@@ -84,7 +80,7 @@ case class ProductTreeLeaf(
             } else {
               ("label.X_litres_X", List(weightOrVolume.toString, name))
             }
-      case "other-goods" =>
+      case "other-goods"           =>
         Some((name, Nil))
     }
 

--- a/app/models/ProductTreeNode.scala
+++ b/app/models/ProductTreeNode.scala
@@ -16,6 +16,8 @@
 
 package models
 
+import utils.FormatsAndConversions
+
 import scala.math.BigDecimal.RoundingMode
 
 sealed trait ProductTreeNode {
@@ -31,7 +33,8 @@ case class ProductTreeLeaf(
   rateID: String,
   templateId: String,
   applicableLimits: List[String]
-) extends ProductTreeNode {
+) extends ProductTreeNode
+    with FormatsAndConversions {
 
   override def isLeaf: Boolean = true
 
@@ -51,13 +54,13 @@ case class ProductTreeLeaf(
               List(
                 noOfSticks.toString,
                 name + ".single",
-                (weightOrVolume * 1000).setScale(2, RoundingMode.HALF_UP).toString
+                (weightOrVolume * 1000).formatDecimalPlaces(2).toString
               )
             )
           } else {
             (
               "label.X_X_Xg",
-              List(noOfSticks.toString, name, (weightOrVolume * 1000).setScale(2, RoundingMode.HALF_UP).toString)
+              List(noOfSticks.toString, name, (weightOrVolume * 1000).formatDecimalPlaces(2).toString)
             )
           }
 
@@ -71,7 +74,7 @@ case class ProductTreeLeaf(
             }
       case "tobacco"               =>
         for (weightOrVolume <- purchasedProductInstance.weightOrVolume)
-          yield ("label.Xg_of_X", List((weightOrVolume * 1000).setScale(2, RoundingMode.HALF_UP).toString, name))
+          yield ("label.Xg_of_X", List((weightOrVolume * 1000).formatDecimalPlaces(2).toString, name))
 
       case "alcohol"     =>
         for (weightOrVolume <- purchasedProductInstance.weightOrVolume)

--- a/app/models/ProductTreeNode.scala
+++ b/app/models/ProductTreeNode.scala
@@ -19,7 +19,6 @@ package models
 import utils.FormatsAndConversions
 
 import util.decimalFormat10
-import utils.FormatsAndConversions
 
 sealed trait ProductTreeNode {
   def name: String

--- a/app/services/AlcoholAndTobaccoCalculationService.scala
+++ b/app/services/AlcoholAndTobaccoCalculationService.scala
@@ -50,7 +50,6 @@ class AlcoholAndTobaccoCalculationService extends FormatsAndConversions {
       )
       .map(_.weightOrVolume.getOrElseZero)
       .sum
-      .bigDecimal
 
   def alcoholAddHelper(
     contextJourneyData: JourneyData,

--- a/app/services/AlcoholAndTobaccoCalculationService.scala
+++ b/app/services/AlcoholAndTobaccoCalculationService.scala
@@ -94,20 +94,6 @@ class AlcoholAndTobaccoCalculationService extends FormatsAndConversions {
 
   def looseTobaccoAddHelper(contextJourneyData: JourneyData, weightOrVolume: Option[BigDecimal]): BigDecimal = {
 
-val previouslyDeclaredChewingTobaccoWeight: BigDecimal =
-      contextJourneyData.declarationResponse
-        .fold[List[PurchasedProductInstance]](List.empty)(_.oldPurchaseProductInstances)
-        .filter(_.path.toString == "tobacco/chewing-tobacco")
-        .map(_.weightOrVolume.getOrElseZero)
-        .sum
-
-    val previouslyDeclaredRollingTobaccoWeight: BigDecimal =
-      contextJourneyData.declarationResponse
-        .fold[List[PurchasedProductInstance]](List.empty)(_.oldPurchaseProductInstances)
-        .filter(_.path.toString == "tobacco/rolling-tobacco")
-        .map(_.weightOrVolume.getOrElseZero)
-        .sum
-
     val previouslyDeclaredLooseTobaccoWeight: BigDecimal =
       sumPreviouslyDeclaredLooseTobaccoWeight(contextJourneyData)
 
@@ -128,20 +114,6 @@ val previouslyDeclaredChewingTobaccoWeight: BigDecimal =
 
     val originalWeight: BigDecimal =
       contextJourneyData.workingInstance.flatMap(_.weightOrVolume).getOrElseZero
-
-    val previouslyDeclaredChewingTobaccoWeight: BigDecimal =
-      contextJourneyData.declarationResponse
-        .fold[List[PurchasedProductInstance]](List.empty)(_.oldPurchaseProductInstances)
-        .filter(_.path.toString == "tobacco/chewing-tobacco")
-        .map(_.weightOrVolume.getOrElseZero)
-        .sum
-
-    val previouslyDeclaredRollingTobaccoWeight: BigDecimal =
-      contextJourneyData.declarationResponse
-        .fold[List[PurchasedProductInstance]](List.empty)(_.oldPurchaseProductInstances)
-        .filter(_.path.toString == "tobacco/rolling-tobacco")
-        .map(_.weightOrVolume.getOrElseZero)
-        .sum
 
     val previouslyDeclaredLooseTobaccoWeight: BigDecimal =
       sumPreviouslyDeclaredLooseTobaccoWeight(contextJourneyData)

--- a/app/util.scala
+++ b/app/util.scala
@@ -19,6 +19,7 @@ import play.api.data.validation.{Constraint, Invalid, Valid, ValidationError}
 import play.api.i18n.Messages
 import play.api.libs.json.{JsArray, JsNull, JsObject, JsValue}
 
+import java.math.RoundingMode
 import java.text.DecimalFormat
 import java.time.format.DateTimeFormatter
 import java.time.{LocalDate, LocalTime}
@@ -27,6 +28,18 @@ import scala.util.Try
 
 // scalastyle:off magic.number
 package object util {
+
+  val decimalFormat10: DecimalFormat = {
+    val df = new DecimalFormat("0.##########")
+    df.setRoundingMode(RoundingMode.DOWN)
+    df
+  }
+
+  val decimalFormat5: DecimalFormat = {
+    val df = new DecimalFormat("0.#####")
+    df.setRoundingMode(RoundingMode.HALF_UP)
+    df
+  }
 
   def formatMonetaryValue(value: String): String = {
     val df            = new DecimalFormat("#,###.00")

--- a/app/utils/FormatsAndConversions.scala
+++ b/app/utils/FormatsAndConversions.scala
@@ -43,6 +43,9 @@ trait FormatsAndConversions {
 
     def formatDecimalPlaces(scale: Int): BigDecimal =
       value.setScale(scale, RoundingMode.HALF_UP)
+
+    def stripTrailingZerosToString: String =
+      value.bigDecimal.stripTrailingZeros().toPlainString
   }
 
   implicit class OptionBigDecimalHelper(value: Option[BigDecimal]) {

--- a/test/controllers/LimitExceedControllerSpec.scala
+++ b/test/controllers/LimitExceedControllerSpec.scala
@@ -73,7 +73,7 @@ class LimitExceedControllerSpec extends BaseSpec {
 
   "loadLimitExceedPage" when {
 
-    ".onPageLoadAddJourney" should {
+    ".onPageLoadAddJourneyAlcoholVolume" should {
 
       "load limit exceeded page for cider and display alcohol content" in {
 
@@ -117,6 +117,102 @@ class LimitExceedControllerSpec extends BaseSpec {
             "They will calculate and take payment of the taxes and duties due."
         )
       }
+
+      "do not load limit exceed page if the path is incorrect" in {
+        when(mockCache.fetch(any())).thenReturn(
+          Future.successful(
+            Some(
+              JourneyData(
+                Some(false),
+                Some("greatBritain"),
+                arrivingNICheck = Some(true),
+                isVatResClaimed = None,
+                isBringingDutyFree = None,
+                bringingOverAllowance = Some(true),
+                ageOver17 = Some(true),
+                privateCraft = Some(false)
+              )
+            )
+          )
+        )
+        val result: Future[Result] = route(
+          app,
+          enhancedFakeRequest(
+            "GET",
+            "/check-tax-on-goods-you-bring-into-the-uk/goods/alcohol/zzz/yyy/upper-limits/volume"
+          )
+        ).get
+        status(result) shouldBe NOT_FOUND
+      }
+    }
+
+    ".onPageLoadAddJourneyTobaccoWeight" should {
+
+      "load limit exceeded page for cigars and display tobacco content" in {
+        when(mockCache.fetch(any())).thenReturn(
+          Future.successful(
+            Some(
+              JourneyData(
+                Some(false),
+                Some("greatBritain"),
+                arrivingNICheck = Some(true),
+                isVatResClaimed = None,
+                isBringingDutyFree = None,
+                bringingOverAllowance = Some(true),
+                ageOver17 = Some(true),
+                privateCraft = Some(false)
+              )
+            )
+          )
+        )
+        val result: Future[Result] = route(
+          app,
+          FakeRequest(
+            "GET",
+            "/check-tax-on-goods-you-bring-into-the-uk/goods/tobacco/rolling-tobacco/upper-limits/weight"
+          ).withSession(SessionKeys.sessionId -> "fakesessionid", "user-amount-input-rolling-tobacco" -> "0.200")
+        ).get
+        status(result) shouldBe OK
+
+        val content = contentAsString(result)
+        val doc     = Jsoup.parse(content)
+
+        doc.getElementsByTag("h1").text() shouldBe "There is a problem"
+        doc
+          .getElementById("entered-amount")
+          .text()                         shouldBe "You have entered a total of 200.00g of rolling tobacco."
+        content                             should include(
+          "You must use the red channel to declare this item in person to Border Force when you arrive in the UK. " +
+            "They will calculate and take payment of the taxes and duties due."
+        )
+      }
+
+      "do not load limit exceed page if the path is incorrect" in {
+        when(mockCache.fetch(any())).thenReturn(
+          Future.successful(
+            Some(
+              JourneyData(
+                Some(false),
+                Some("greatBritain"),
+                arrivingNICheck = Some(true),
+                isVatResClaimed = None,
+                isBringingDutyFree = None,
+                bringingOverAllowance = Some(true),
+                ageOver17 = Some(true),
+                privateCraft = Some(false)
+              )
+            )
+          )
+        )
+        val result: Future[Result] = route(
+          app,
+          enhancedFakeRequest("GET", "/check-tax-on-goods-you-bring-into-the-uk/goods/zzz/yyy/upper-limits/weight")
+        ).get
+        status(result) shouldBe NOT_FOUND
+      }
+    }
+
+    ".onPageLoadAddJourneyNoOfSticks" should {
 
       "load limit exceeded page for cigars and display tobacco content" in {
         when(mockCache.fetch(any())).thenReturn(
@@ -176,7 +272,10 @@ class LimitExceedControllerSpec extends BaseSpec {
         )
         val result: Future[Result] = route(
           app,
-          enhancedFakeRequest("GET", "/check-tax-on-goods-you-bring-into-the-uk/goods/yyy/zzz/upper-limits")
+          enhancedFakeRequest(
+            "GET",
+            "/check-tax-on-goods-you-bring-into-the-uk/goods/zzz/yyyy/upper-limits/units-of-product"
+          )
         ).get
         status(result) shouldBe NOT_FOUND
       }
@@ -299,6 +398,143 @@ class LimitExceedControllerSpec extends BaseSpec {
           enhancedFakeRequest("GET", "/check-tax-on-goods-you-bring-into-the-uk/goods/yyy/zzz/upper-limits")
         ).get
         status(result) shouldBe NOT_FOUND
+      }
+    }
+
+    ".onPageLoadEditTobaccoWeight" should {
+
+      "load limit exceeded page for chewing tobacco and display tobacco content" in {
+
+        when(mockCache.fetch(any())).thenReturn(
+          Future.successful(
+            Some(
+              JourneyData(
+                Some(false),
+                Some("greatBritain"),
+                arrivingNICheck = Some(true),
+                isVatResClaimed = None,
+                isBringingDutyFree = None,
+                bringingOverAllowance = Some(true),
+                ageOver17 = Some(true),
+                privateCraft = Some(false),
+                purchasedProductInstances = List(
+                  PurchasedProductInstance(
+                    path = ProductPath("tobacco/chewing-tobacco"),
+                    iid = "iid0",
+                    weightOrVolume = Some(0.9),
+                    noOfSticks = None,
+                    country = None,
+                    originCountry = None,
+                    currency = Some("EUR"),
+                    cost = Some(BigDecimal(12.99))
+                  )
+                ),
+                workingInstance = Some(
+                  PurchasedProductInstance(
+                    path = ProductPath("tobacco/chewing-tobacco"),
+                    iid = "iid0",
+                    weightOrVolume = Some(0.9),
+                    noOfSticks = None,
+                    country = None,
+                    originCountry = None,
+                    currency = Some("EUR"),
+                    cost = Some(BigDecimal(12.99))
+                  )
+                )
+              )
+            )
+          )
+        )
+        val result: Future[Result] = route(
+          app,
+          FakeRequest(
+            "GET",
+            "/check-tax-on-goods-you-bring-into-the-uk/goods/tobacco/chewing-tobacco/upper-limits/edit/weight"
+          ).withSession(SessionKeys.sessionId -> "fakesessionid", "user-amount-input-chewing-tobacco" -> "1.100")
+        ).get
+        status(result) shouldBe OK
+
+        val content = contentAsString(result)
+        val doc     = Jsoup.parse(content)
+
+        doc.getElementsByTag("h1").text() shouldBe "There is a problem"
+        doc
+          .getElementById("entered-amount")
+          .text()                         shouldBe "You changed 900.00g of pipe or chewing tobacco to 1100.00g of pipe or chewing tobacco."
+        doc
+          .getElementById("new-total-amount")
+          .text()                         shouldBe "This means your total is now 1100.00g of pipe or chewing tobacco."
+        content                             should include(
+          "You must use the red channel to declare this item in person to Border Force when you arrive in the UK. " +
+            "They will calculate and take payment of the taxes and duties due."
+        )
+      }
+
+      "load limit exceeded page for rolling tobacco and display tobacco content" in {
+
+        when(mockCache.fetch(any())).thenReturn(
+          Future.successful(
+            Some(
+              JourneyData(
+                Some(false),
+                Some("greatBritain"),
+                arrivingNICheck = Some(true),
+                isVatResClaimed = None,
+                isBringingDutyFree = None,
+                bringingOverAllowance = Some(true),
+                ageOver17 = Some(true),
+                privateCraft = Some(false),
+                purchasedProductInstances = List(
+                  PurchasedProductInstance(
+                    path = ProductPath("tobacco/rolling-tobacco"),
+                    iid = "iid0",
+                    weightOrVolume = Some(0.9),
+                    noOfSticks = None,
+                    country = None,
+                    originCountry = None,
+                    currency = Some("EUR"),
+                    cost = Some(BigDecimal(12.99))
+                  )
+                ),
+                workingInstance = Some(
+                  PurchasedProductInstance(
+                    path = ProductPath("tobacco/rolling-tobacco"),
+                    iid = "iid0",
+                    weightOrVolume = Some(0.9),
+                    noOfSticks = None,
+                    country = None,
+                    originCountry = None,
+                    currency = Some("EUR"),
+                    cost = Some(BigDecimal(12.99))
+                  )
+                )
+              )
+            )
+          )
+        )
+        val result: Future[Result] = route(
+          app,
+          FakeRequest(
+            "GET",
+            "/check-tax-on-goods-you-bring-into-the-uk/goods/tobacco/rolling-tobacco/upper-limits/edit/weight"
+          ).withSession(SessionKeys.sessionId -> "fakesessionid", "user-amount-input-rolling-tobacco" -> "1.100")
+        ).get
+        status(result) shouldBe OK
+
+        val content = contentAsString(result)
+        val doc     = Jsoup.parse(content)
+
+        doc.getElementsByTag("h1").text() shouldBe "There is a problem"
+        doc
+          .getElementById("entered-amount")
+          .text()                         shouldBe "You changed 900.00g of rolling tobacco to 1100.00g of rolling tobacco."
+        doc
+          .getElementById("new-total-amount")
+          .text()                         shouldBe "This means your total is now 1100.00g of rolling tobacco."
+        content                             should include(
+          "You must use the red channel to declare this item in person to Border Force when you arrive in the UK. " +
+            "They will calculate and take payment of the taxes and duties due."
+        )
       }
     }
 

--- a/test/models/CalculatorServiceRequestSpec.scala
+++ b/test/models/CalculatorServiceRequestSpec.scala
@@ -185,8 +185,8 @@ class CalculatorServiceRequestSpec extends BaseSpec {
           |    "isExcisePaid":false,
           |    "isCustomPaid":true,
           |    "metadata" : {
-          |      "description" : "1000.00g of dummy product name",
-          |      "descriptionLabels":{"description":"label.Xg_of_X","args":["1000.00","Dummy product name"]},
+          |      "description" : "1000g of dummy product name",
+          |      "descriptionLabels":{"description":"label.Xg_of_X","args":["1000","Dummy product name"]},
           |      "name" : "Dummy product name",
           |      "cost" : "2.00",
           |      "currency" : {

--- a/test/services/AlcoholAndTobaccoCalculationServiceSpec.scala
+++ b/test/services/AlcoholAndTobaccoCalculationServiceSpec.scala
@@ -16,7 +16,7 @@
 
 package services
 
-import models._
+import models.{LiabilityDetails, _}
 import util.BaseSpec
 
 class AlcoholAndTobaccoCalculationServiceSpec extends BaseSpec {
@@ -100,6 +100,171 @@ class AlcoholAndTobaccoCalculationServiceSpec extends BaseSpec {
 
             val actual   = service.alcoholAddHelper(data, alcoholDtoVolume, "beer")
             val expected = 0.8
+
+            actual shouldBe expected
+          }
+        }
+
+        "there is a previous declaration" should {
+
+          "return the sum of (all beer products + the volume from the AlcoholDto + previously declared alcohol products" in {
+
+            val previousDeclarationResponse =
+              DeclarationResponse(
+                Calculation("0.00", "0.00", "0.00", "0.00"),
+                LiabilityDetails("", "", "", ""),
+                List(
+                  PurchasedProductInstance(
+                    ProductPath("alcohol/beer"),
+                    iid = "item1",
+                    weightOrVolume = Some(0.1)
+                  )
+                ),
+                amendmentCount = None
+              )
+
+            val data = JourneyData(
+              purchasedProductInstances = List(
+                PurchasedProductInstance(
+                  ProductPath("alcohol/beer"),
+                  iid = "item1",
+                  weightOrVolume = Some(0.1)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("alcohol/beer"),
+                  iid = "item2",
+                  weightOrVolume = Some(0.1)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("alcohol/beer"),
+                  iid = "item3",
+                  weightOrVolume = Some(0.1)
+                )
+              ),
+              declarationResponse = Some(previousDeclarationResponse)
+            )
+
+            val alcoholDtoVolume = BigDecimal(0.5)
+
+            val actual   = service.alcoholAddHelper(data, alcoholDtoVolume, "beer")
+            val expected = 0.9
+
+            actual shouldBe expected
+          }
+        }
+      }
+
+      ".noOfSticksTobaccoAddHelper" when {
+
+        "there are multiple cigarette tobacco products" should {
+
+          "return the sum of all cigarette tobacco product units, plus the units from the TobaccoDto" in {
+
+            val data = JourneyData(
+              purchasedProductInstances = List(
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarettes"),
+                  iid = "item1",
+                  noOfSticks = Some(10)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarettes"),
+                  iid = "item2",
+                  noOfSticks = Some(10)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarettes"),
+                  iid = "item3",
+                  noOfSticks = Some(10)
+                )
+              )
+            )
+
+            val tobaccoDtoWeight = Some(50)
+
+            val actual   = service.noOfSticksTobaccoAddHelper(data, tobaccoDtoWeight, "tobacco/cigarettes")
+            val expected = 80
+
+            actual shouldBe expected
+          }
+        }
+
+        "there are multiple cigarillo products" should {
+
+          "return the sum of all cigarillo tobacco product units, plus the units from the TobaccoDto" in {
+
+            val data = JourneyData(
+              purchasedProductInstances = List(
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarillos"),
+                  iid = "item1",
+                  noOfSticks = Some(10)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarillos"),
+                  iid = "item2",
+                  noOfSticks = Some(10)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarillos"),
+                  iid = "item3",
+                  noOfSticks = Some(10)
+                )
+              )
+            )
+
+            val tobaccoDtoWeight = Some(50)
+
+            val actual   = service.noOfSticksTobaccoAddHelper(data, tobaccoDtoWeight, "tobacco/cigarillos")
+            val expected = 80
+
+            actual shouldBe expected
+          }
+        }
+
+        "there is a previous declaration" should {
+
+          "return the sum of all cigarettes tobacco product units, plus the units from the TobaccoDto" in {
+
+            val previousDeclarationResponse =
+              DeclarationResponse(
+                Calculation("0.00", "0.00", "0.00", "0.00"),
+                LiabilityDetails("", "", "", ""),
+                List(
+                  PurchasedProductInstance(
+                    ProductPath("tobacco/cigarettes"),
+                    iid = "item0",
+                    noOfSticks = Some(10)
+                  )
+                ),
+                amendmentCount = None
+              )
+
+            val data = JourneyData(
+              purchasedProductInstances = List(
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarettes"),
+                  iid = "item1",
+                  noOfSticks = Some(10)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarettes"),
+                  iid = "item2",
+                  noOfSticks = Some(10)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarettes"),
+                  iid = "item3",
+                  noOfSticks = Some(10)
+                )
+              ),
+              declarationResponse = Some(previousDeclarationResponse)
+            )
+
+            val tobaccoDtoWeight = Some(50)
+
+            val actual   = service.noOfSticksTobaccoAddHelper(data, tobaccoDtoWeight, "tobacco/cigarettes")
+            val expected = 90
 
             actual shouldBe expected
           }
@@ -210,6 +375,54 @@ class AlcoholAndTobaccoCalculationServiceSpec extends BaseSpec {
             actual shouldBe expected
           }
         }
+
+        "there is a previous declaration" should {
+
+          "return the sum of (all chewing-tobacco products + the volume from the TobaccoDto + previously declared chewing-tobacco products)" in {
+
+            val previousDeclarationResponse =
+              DeclarationResponse(
+                Calculation("0.00", "0.00", "0.00", "0.00"),
+                LiabilityDetails("", "", "", ""),
+                List(
+                  PurchasedProductInstance(
+                    ProductPath("tobacco/chewing-tobacco"),
+                    iid = "item0",
+                    weightOrVolume = Some(0.1)
+                  )
+                ),
+                amendmentCount = None
+              )
+
+            val data = JourneyData(
+              purchasedProductInstances = List(
+                PurchasedProductInstance(
+                  ProductPath("tobacco/chewing-tobacco"),
+                  iid = "item1",
+                  weightOrVolume = Some(0.1)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/chewing-tobacco"),
+                  iid = "item2",
+                  weightOrVolume = Some(0.1)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/chewing-tobacco"),
+                  iid = "item3",
+                  weightOrVolume = Some(0.1)
+                )
+              ),
+              declarationResponse = Some(previousDeclarationResponse)
+            )
+
+            val tobaccoDtoWeight = BigDecimal(0.5)
+
+            val actual   = service.looseTobaccoAddHelper(data, Some(tobaccoDtoWeight))
+            val expected = 0.9
+
+            actual shouldBe expected
+          }
+        }
       }
     }
 
@@ -301,6 +514,203 @@ class AlcoholAndTobaccoCalculationServiceSpec extends BaseSpec {
             actual shouldBe expected
           }
         }
+      }
+
+      ".noOfSticksTobaccoEditHelper" when {
+
+        "there are multiple cigarettes products" should {
+
+          "return the sum of all cigarettes product units, plus the (TobaccoDtoNoOfSticks minus WorkingInstanceNoOfSticks(aka product being edited))" in {
+
+            val data = JourneyData(
+              purchasedProductInstances = List(
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarettes"),
+                  iid = "item1",
+                  noOfSticks = Some(10)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarettes"),
+                  iid = "item2",
+                  noOfSticks = Some(10)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarettes"),
+                  iid = "item3",
+                  noOfSticks = Some(10)
+                )
+              ),
+              workingInstance = Some(
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarettes"),
+                  iid = "item1",
+                  noOfSticks = Some(10)
+                )
+              )
+            )
+
+            val tobaccoDtoWeight = Some(50)
+            val actual           = service.noOfSticksTobaccoEditHelper(data, tobaccoDtoWeight, "tobacco/cigarettes")
+            val expected         = 70
+
+            actual shouldBe expected
+          }
+        }
+
+        "there are multiple cigarillo products" should {
+
+          "return the sum of all cigarillo product units, plus the (TobaccoDtoNoOfSticks minus WorkingInstanceNoOfSticks(aka product being edited))" in {
+
+            val data = JourneyData(
+              purchasedProductInstances = List(
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarillo"),
+                  iid = "item1",
+                  noOfSticks = Some(10)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarillo"),
+                  iid = "item2",
+                  noOfSticks = Some(10)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarillo"),
+                  iid = "item3",
+                  noOfSticks = Some(10)
+                )
+              ),
+              workingInstance = Some(
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarillo"),
+                  iid = "item1",
+                  noOfSticks = Some(10)
+                )
+              )
+            )
+
+            val tobaccoDtoWeight = Some(50)
+            val actual           = service.noOfSticksTobaccoEditHelper(data, tobaccoDtoWeight, "tobacco/cigarillo")
+            val expected         = 70
+
+            actual shouldBe expected
+          }
+        }
+
+        "for cigarillo products and there are other kinds of mixed tobacco products" should {
+
+          "return only the sum of all cigarillo product units, plus the (TobaccoDtoNoOfSticks minus WorkingInstanceNoOfSticks(aka product being edited))" in {
+
+            val data = JourneyData(
+              purchasedProductInstances = List(
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarillo"),
+                  iid = "item1",
+                  noOfSticks = Some(10),
+                  weightOrVolume = Some(0.1)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarillo"),
+                  iid = "item2",
+                  noOfSticks = Some(10),
+                  weightOrVolume = Some(0.1)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarillo"),
+                  iid = "item3",
+                  noOfSticks = Some(10),
+                  weightOrVolume = Some(0.1)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarillo"),
+                  iid = "item4",
+                  noOfSticks = Some(10),
+                  weightOrVolume = Some(0.1)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigars"),
+                  iid = "item5",
+                  noOfSticks = Some(100),
+                  weightOrVolume = Some(0.1)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarettes"),
+                  iid = "item6",
+                  noOfSticks = Some(300),
+                  weightOrVolume = None
+                )
+              ),
+              workingInstance = Some(
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarillo"),
+                  iid = "item1",
+                  weightOrVolume = Some(10)
+                )
+              )
+            )
+
+            val tobaccoDtoWeight = Some(50)
+
+            val actual   = service.noOfSticksTobaccoEditHelper(data, tobaccoDtoWeight, "tobacco/cigarillo")
+            val expected = 90
+
+            actual shouldBe expected
+          }
+        }
+
+        "there is a previous declaration" should {
+
+          "return the sum of (all cigarettes tobacco product units + the units from the edited TobaccoDto/workingInstance + previously declared chewing-tobacco products)" in {
+
+            val previousDeclarationResponse =
+              DeclarationResponse(
+                Calculation("0.00", "0.00", "0.00", "0.00"),
+                LiabilityDetails("", "", "", ""),
+                List(
+                  PurchasedProductInstance(
+                    ProductPath("tobacco/cigarettes"),
+                    iid = "item0",
+                    noOfSticks = Some(10)
+                  )
+                ),
+                amendmentCount = None
+              )
+
+            val data = JourneyData(
+              purchasedProductInstances = List(
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarettes"),
+                  iid = "item1",
+                  noOfSticks = Some(10)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarettes"),
+                  iid = "item2",
+                  noOfSticks = Some(10)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarettes"),
+                  iid = "item3",
+                  noOfSticks = Some(10)
+                )
+              ),
+              workingInstance = Some(
+                PurchasedProductInstance(
+                  ProductPath("tobacco/cigarettes"),
+                  iid = "item1",
+                  noOfSticks = Some(10)
+                )
+              ),
+              declarationResponse = Some(previousDeclarationResponse)
+            )
+
+            val tobaccoDtoWeight = Some(50)
+            val actual           = service.noOfSticksTobaccoEditHelper(data, tobaccoDtoWeight, "tobacco/cigarettes")
+            val expected         = 80
+
+            actual shouldBe expected
+          }
+        }
+
       }
 
       ".looseTobaccoEditHelper" when {
@@ -480,6 +890,60 @@ class AlcoholAndTobaccoCalculationServiceSpec extends BaseSpec {
 
             val actual   = service.looseTobaccoEditHelper(data, tobaccoDtoWeight)
             val expected = BigDecimal(0.60000)
+
+            actual shouldBe expected
+          }
+        }
+
+        "there is a previous declaration" should {
+
+          "return the sum of (all chewing-tobacco products + the volume from the edited TobaccoDto/workingInstance + previously declared chewing-tobacco products)" in {
+
+            val previousDeclarationResponse =
+              DeclarationResponse(
+                Calculation("0.00", "0.00", "0.00", "0.00"),
+                LiabilityDetails("", "", "", ""),
+                List(
+                  PurchasedProductInstance(
+                    ProductPath("tobacco/chewing-tobacco"),
+                    iid = "item0",
+                    weightOrVolume = Some(0.1)
+                  )
+                ),
+                amendmentCount = None
+              )
+
+            val data = JourneyData(
+              purchasedProductInstances = List(
+                PurchasedProductInstance(
+                  ProductPath("tobacco/chewing-tobacco"),
+                  iid = "item1",
+                  weightOrVolume = Some(0.1)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/chewing-tobacco"),
+                  iid = "item2",
+                  weightOrVolume = Some(0.2)
+                ),
+                PurchasedProductInstance(
+                  ProductPath("tobacco/chewing-tobacco"),
+                  iid = "item3",
+                  weightOrVolume = Some(0.2)
+                )
+              ),
+              workingInstance = Some(
+                PurchasedProductInstance(
+                  ProductPath("tobacco/chewing-tobacco"),
+                  iid = "item1",
+                  weightOrVolume = Some(0.1)
+                )
+              ),
+              declarationResponse = Some(previousDeclarationResponse)
+            )
+
+            val tobaccoDtoWeight = Some(BigDecimal(0.5))
+            val actual           = service.looseTobaccoEditHelper(data, tobaccoDtoWeight)
+            val expected         = BigDecimal(1.00000)
 
             actual shouldBe expected
           }

--- a/test/util/UtilSpec.scala
+++ b/test/util/UtilSpec.scala
@@ -19,7 +19,39 @@ package util
 import models.ProductPath
 import play.api.data.validation._
 
+import java.math.RoundingMode
+
 class UtilSpec extends BaseSpec {
+
+  "Formatting with decimalFormat5" when {
+    "using the HALF_UP rounding mode" should {
+      "preserve the correct value in 5 decimal places" in {
+        val (start, end, step): (BigDecimal, BigDecimal, BigDecimal) = (0.00, 0.99, 0.01)
+
+        start
+          .to(end, step)
+          .foreach(value =>
+            BigDecimal(decimalFormat5.format(value.toDouble / 1000)) shouldBe BigDecimal(
+              decimalFormat5.format(value / 1000)
+            )
+          )
+      }
+
+      "using the UP rounding mode" should {
+        "not preserve the correct value in 5 decimal places" in {
+          val values: Seq[BigDecimal] = Seq(0.07, 0.13, 0.14, 0.26, 0.28, 0.52, 0.56, 0.77, 0.81, 0.89)
+
+          decimalFormat5.setRoundingMode(RoundingMode.UP)
+
+          values.foreach(value =>
+            BigDecimal(decimalFormat5.format(value.toDouble / 1000)) should not be BigDecimal(
+              decimalFormat5.format(value / 1000)
+            )
+          )
+        }
+      }
+    }
+  }
 
   "Validating a cost" should {
 


### PR DESCRIPTION
…erage and add more unit tests to AlcoholTobaccoCalculation service

- The changes for DDCE-4964/previous iteration did not account for previous declarations, such as on an amend journey. There is data stored in declarationReponse which must be checked and added to the total/validation. Also increased test coverage as some new methods introduced was not tested.

~~TODO: revert dashboard no decimal litres and gram amounts to just whole integers~~
Trailing zeros have been stripped for whole integers for tobacco products.